### PR TITLE
Turning the /stats endpoint into prometheus /metrics endpoint

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -6,5 +6,7 @@ WORKDIR     /ghmirror
 
 COPY        . ./
 
+RUN         make develop
+
 ENTRYPOINT  ["make"]
 CMD         ["check"]

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,27 @@
 all:
 	@echo
 	@echo "Targets:"
+	@echo "prepare:      Installs pipenv."
+	@echo "install:      Installs the ghmirror package and its dependencies."
+	@echo "develop:      Installs the ghmirror package, its dependencies and its development dependencies."
 	@echo "check:        Runs the style check, the code check and the tests."
-	@echo "run-app:      Runs the app server (debug mode)."
+	@echo "run:          Runs the app server (debug mode)."
 	@echo
 
-install:
-	pip install pipenv
 
-check: install
+prepare:
+	pip install pipenv --upgrade
+
+install: prepare
+	pipenv install
+
+develop: prepare
 	pipenv install --dev
+
+check:
 	pipenv run flake8 ghmirror
 	pipenv run pylint ghmirror
 	pipenv run pipenv run pytest -v --forked --cov=ghmirror --cov-report=term-missing tests/
 
-run-app: install
-	pipenv install
+run:
 	pipenv run python ghmirror/app/__init__.py

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -107,6 +107,12 @@
             ],
             "version": "==1.1.1"
         },
+        "prometheus-client": {
+            "hashes": [
+                "sha256:71cd24a2b3eb335cb800c7159f423df1bd4dcd5171b234be15e3f31ec9f622da"
+            ],
+            "version": "==0.7.1"
+        },
         "requests": {
             "hashes": [
                 "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
@@ -394,10 +400,10 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:ccc94ed0909b58ffe34430ea5451f07bc0c76467d7081619a454bf5c98b89e28",
-                "sha256:feae2f18633c32fc71f2de629bfb3bd3c9325cd4419642b1f1da42ee488d9b98"
+                "sha256:5c56e330306215cd3553342cfafc73dda2c60792384117893f3a83f8a1209f50",
+                "sha256:d65287feb793213ffe11c0f31b81602be31448f38aeb8ffc2eb286c4f6f6657e"
             ],
-            "version": "==2.1.0"
+            "version": "==2.2.0"
         }
     }
 }

--- a/ghmirror/app/response.py
+++ b/ghmirror/app/response.py
@@ -32,8 +32,9 @@ class MirrorResponse:
     :type gh_api_url: str
     :type gh_mirror_url: str
     """
-    def __init__(self, original_response, gh_api_url, gh_mirror_url):
+    def __init__(self, original_response, headers, gh_api_url, gh_mirror_url):
         self._original_response = original_response
+        self._headers = headers
         self._gh_api_url = gh_api_url.rstrip('/')
         self._gh_mirror_url = gh_mirror_url.rstrip('/')
 
@@ -47,7 +48,7 @@ class MirrorResponse:
         :return: the sanitized headers
         :rtype: dict
         """
-        sanitized_headers = dict()
+        sanitized_headers = self._headers
 
         link = self._original_response.headers.get('Link')
         if link is not None:

--- a/ghmirror/decorators/metrics.py
+++ b/ghmirror/decorators/metrics.py
@@ -1,0 +1,58 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2020
+# Author: Amador Pahim <apahim@redhat.com>
+
+"""
+Metrics decorators.
+"""
+
+import time
+
+from functools import wraps
+
+import flask
+
+from ghmirror.data_structures.monostate import StatsCache
+
+
+STATS_CACHE = StatsCache()
+
+
+def requests_metrics(function):
+    """
+    Decorator to collect metrics from the request and populate the
+    StatsCache object.
+    """
+    @wraps(function)
+    def wrapper(*args, **kwargs):
+        start = time.time()
+        response = function(*args, **kwargs)
+
+        # This is the total time spent to process the request
+        elapsed_time = (time.time() - start)
+
+        # Incrementing the total requests couter
+        STATS_CACHE.count()
+
+        # The X-Cache header is added by the flask APP
+        # and it contains either HIT or MISS
+        cache = response.headers['X-Cache']
+
+        # Adding the request metrics to the histogram
+        STATS_CACHE.observe(cache=cache,
+                            status=response.status_code,
+                            value=elapsed_time,
+                            method=flask.request.method)
+
+        return response
+    return wrapper

--- a/setup.py
+++ b/setup.py
@@ -28,4 +28,5 @@ setup(name='ghmirror',
             'Topic :: Internet :: WWW/HTTP :: WSGI :: Middleware',
       ],
       install_requires=['Flask~=1.1',
-                        'requests~=2.22'])
+                        'requests~=2.22',
+                        'prometheus_client~=0.7'])

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -55,66 +55,75 @@ def test_healthz(client):
             side_effect=mocked_requests_get_etag)
 def test_mirror_etag(mock_get, client):
     # Initially the stats are zeroed
-    response = client.get('/stats')
-    expected_data = {'cache_hit': 0,
-                     'cache_miss': 0}
+    response = client.get('/metrics')
     assert response.status_code == 200
-    assert response.json == expected_data
+    assert ('request_latency_seconds_count{cache="HIT",'
+            'method="GET",status="200"}') not in str(response.data)
+    assert ('request_latency_seconds_count{cache="MISS",'
+            'method="GET",status="200"}') not in str(response.data)
 
     response = client.get('/repos/app-sre/github-mirror',
                           follow_redirects=True)
     assert response.status_code == 200
 
     # First get is a cache_miss
-    response = client.get('/stats', follow_redirects=True)
-    expected_data = {'cache_hit': 0,
-                     'cache_miss': 1}
+    response = client.get('/metrics', follow_redirects=True)
+
     assert response.status_code == 200
-    assert response.json == expected_data
+    assert ('request_latency_seconds_count{cache="HIT",'
+            'method="GET",status="200"}') not in str(response.data)
+    assert ('request_latency_seconds_count{cache="MISS",'
+            'method="GET",status="200"} 1.0') in str(response.data)
 
     response = client.get('/repos/app-sre/github-mirror',
                           follow_redirects=True)
     assert response.status_code == 200
 
     # Second get is a cache_hit
-    response = client.get('/stats', follow_redirects=True)
-    expected_data = {'cache_hit': 1,
-                     'cache_miss': 1}
+    response = client.get('/metrics', follow_redirects=True)
+
     assert response.status_code == 200
-    assert response.json == expected_data
+    assert ('request_latency_seconds_count{cache="HIT",'
+            'method="GET",status="200"} 1.0') in str(response.data)
+    assert ('request_latency_seconds_count{cache="MISS",'
+            'method="GET",status="200"} 1.0') in str(response.data)
 
 
 @mock.patch('ghmirror.app.requests.request',
             side_effect=mocked_requests_get_last_modified)
 def test_mirror_last_modified(mock_get, client):
     # Initially the stats are zeroed
-    response = client.get('/stats')
-    expected_data = {'cache_hit': 0,
-                     'cache_miss': 0}
+    response = client.get('/metrics')
     assert response.status_code == 200
-    assert response.json == expected_data
+    assert ('request_latency_seconds_count{cache="HIT",'
+            'method="GET",status="200"}') not in str(response.data)
+    assert ('request_latency_seconds_count{cache="MISS",'
+            'method="GET",status="200"}') not in str(response.data)
 
     response = client.get('/repos/app-sre/github-mirror',
                           follow_redirects=True)
     assert response.status_code == 200
 
     # First get is a cache_miss
-    response = client.get('/stats', follow_redirects=True)
-    expected_data = {'cache_hit': 0,
-                     'cache_miss': 1}
+    response = client.get('/metrics', follow_redirects=True)
+
     assert response.status_code == 200
-    assert response.json == expected_data
+    assert ('request_latency_seconds_count{cache="HIT",'
+            'method="GET",status="200"}') not in str(response.data)
+    assert ('request_latency_seconds_count{cache="MISS",'
+            'method="GET",status="200"} 1.0') in str(response.data)
 
     response = client.get('/repos/app-sre/github-mirror',
                           follow_redirects=True)
     assert response.status_code == 200
 
     # Second get is a cache_hit
-    response = client.get('/stats', follow_redirects=True)
-    expected_data = {'cache_hit': 1,
-                     'cache_miss': 1}
+    response = client.get('/metrics', follow_redirects=True)
     assert response.status_code == 200
-    assert response.json == expected_data
+    assert ('request_latency_seconds_count{cache="HIT",'
+            'method="GET",status="200"} 1.0') in str(response.data)
+    assert ('request_latency_seconds_count{cache="MISS",'
+            'method="GET",status="200"} 1.0') in str(response.data)
 
 
 @mock.patch('ghmirror.app.requests.request',

--- a/tests/unit/test_monostate.py
+++ b/tests/unit/test_monostate.py
@@ -11,28 +11,21 @@ class TestStatsCache:
         with pytest.raises(AttributeError) as e_info:
             stats_cache_01.foo
             assert 'object has no attribute' in e_info.message
-        assert stats_cache_01.hits == 0
-        assert stats_cache_01.misses == 0
+        assert stats_cache_01.counter._value._value == 0
 
-        stats_cache_01.hit()
-        stats_cache_01.hit()
-        stats_cache_01.miss()
-        stats_cache_01.miss()
-        stats_cache_01.miss()
-        stats_cache_01.miss()
-        assert stats_cache_01.hits == 2
-        assert stats_cache_01.misses == 4
+        stats_cache_01.count()
+        stats_cache_01.count()
+
+        assert stats_cache_01.counter._value._value == 2
 
         stats_cache_02 = StatsCache()
-        assert stats_cache_02.hits == 2
-        assert stats_cache_02.misses == 4
+        assert stats_cache_02.counter._value._value == 2
 
-        stats_cache_02.hit()
-        stats_cache_02.miss()
-        assert stats_cache_01.hits == 3
-        assert stats_cache_01.misses == 5
-        assert stats_cache_02.hits == 3
-        assert stats_cache_02.misses == 5
+        stats_cache_02.count()
+        stats_cache_02.count()
+
+        assert stats_cache_01.counter._value._value == 4
+        assert stats_cache_02.counter._value._value == 4
 
 
 class MockResponse:

--- a/tests/unit/test_reponse.py
+++ b/tests/unit/test_reponse.py
@@ -25,6 +25,7 @@ class TestResponse:
                                      headers=headers,
                                      status_code=200)
         response = MirrorResponse(original_response=mock_response,
+                                  headers={},
                                   gh_api_url='foo',
                                   gh_mirror_url='bar')
 
@@ -42,6 +43,7 @@ class TestResponse:
                                      status_code=200)
 
         response = MirrorResponse(original_response=mock_response,
+                                  headers={},
                                   gh_api_url='foo',
                                   gh_mirror_url='bar')
 
@@ -66,6 +68,8 @@ class TestResponse:
                                      status_code=200)
 
         response = MirrorResponse(original_response=mock_response,
+                                  headers={},
+
                                   gh_api_url='foo',
                                   gh_mirror_url='bar')
 
@@ -79,6 +83,7 @@ class TestResponse:
                                      status_code=200)
 
         response = MirrorResponse(original_response=mock_response,
+                                  headers={},
                                   gh_api_url='foo',
                                   gh_mirror_url='bar')
 


### PR DESCRIPTION
Example::

    # HELP process_virtual_memory_bytes Virtual memory size in bytes.
    # TYPE process_virtual_memory_bytes gauge
    process_virtual_memory_bytes 6.32803328e+08
    # HELP process_resident_memory_bytes Resident memory size in bytes.
    # TYPE process_resident_memory_bytes gauge
    process_resident_memory_bytes 3.6941824e+07
    # HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
    # TYPE process_start_time_seconds gauge
    process_start_time_seconds 1.58168813995e+09
    # HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
    # TYPE process_cpu_seconds_total counter
    process_cpu_seconds_total 9.69
    # HELP process_open_fds Number of open file descriptors.
    # TYPE process_open_fds gauge
    process_open_fds 9.0
    # HELP process_max_fds Maximum number of open file descriptors.
    # TYPE process_max_fds gauge
    process_max_fds 1024.0
    # HELP http_request_total total requests
    # TYPE http_request_total counter
    http_request_total 199.0
    # TYPE http_request_created gauge
    http_request_created 1.5816881418336885e+09
    # HELP request_latency_seconds Description of histogram
    # TYPE request_latency_seconds histogram
    request_latency_seconds_bucket{cache="MISS",le="0.005",method="GET",status="404"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.01",method="GET",status="404"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.025",method="GET",status="404"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.05",method="GET",status="404"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.075",method="GET",status="404"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.1",method="GET",status="404"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.25",method="GET",status="404"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.5",method="GET",status="404"} 51.0
    request_latency_seconds_bucket{cache="MISS",le="0.75",method="GET",status="404"} 58.0
    request_latency_seconds_bucket{cache="MISS",le="1.0",method="GET",status="404"} 60.0
    request_latency_seconds_bucket{cache="MISS",le="2.5",method="GET",status="404"} 60.0
    request_latency_seconds_bucket{cache="MISS",le="5.0",method="GET",status="404"} 60.0
    request_latency_seconds_bucket{cache="MISS",le="7.5",method="GET",status="404"} 60.0
    request_latency_seconds_bucket{cache="MISS",le="10.0",method="GET",status="404"} 60.0
    request_latency_seconds_bucket{cache="MISS",le="+Inf",method="GET",status="404"} 60.0
    request_latency_seconds_count{cache="MISS",method="GET",status="404"} 60.0
    request_latency_seconds_sum{cache="MISS",method="GET",status="404"} 29.620453357696533
    request_latency_seconds_bucket{cache="MISS",le="0.005",method="GET",status="200"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.01",method="GET",status="200"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.025",method="GET",status="200"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.05",method="GET",status="200"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.075",method="GET",status="200"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.1",method="GET",status="200"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.25",method="GET",status="200"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.5",method="GET",status="200"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.75",method="GET",status="200"} 6.0
    request_latency_seconds_bucket{cache="MISS",le="1.0",method="GET",status="200"} 7.0
    request_latency_seconds_bucket{cache="MISS",le="2.5",method="GET",status="200"} 7.0
    request_latency_seconds_bucket{cache="MISS",le="5.0",method="GET",status="200"} 7.0
    request_latency_seconds_bucket{cache="MISS",le="7.5",method="GET",status="200"} 7.0
    request_latency_seconds_bucket{cache="MISS",le="10.0",method="GET",status="200"} 7.0
    request_latency_seconds_bucket{cache="MISS",le="+Inf",method="GET",status="200"} 7.0
    request_latency_seconds_count{cache="MISS",method="GET",status="200"} 7.0
    request_latency_seconds_sum{cache="MISS",method="GET",status="200"} 4.457277536392212
    request_latency_seconds_bucket{cache="HIT",le="0.005",method="GET",status="200"} 0.0
    request_latency_seconds_bucket{cache="HIT",le="0.01",method="GET",status="200"} 0.0
    request_latency_seconds_bucket{cache="HIT",le="0.025",method="GET",status="200"} 0.0
    request_latency_seconds_bucket{cache="HIT",le="0.05",method="GET",status="200"} 0.0
    request_latency_seconds_bucket{cache="HIT",le="0.075",method="GET",status="200"} 0.0
    request_latency_seconds_bucket{cache="HIT",le="0.1",method="GET",status="200"} 0.0
    request_latency_seconds_bucket{cache="HIT",le="0.25",method="GET",status="200"} 0.0
    request_latency_seconds_bucket{cache="HIT",le="0.5",method="GET",status="200"} 0.0
    request_latency_seconds_bucket{cache="HIT",le="0.75",method="GET",status="200"} 124.0
    request_latency_seconds_bucket{cache="HIT",le="1.0",method="GET",status="200"} 130.0
    request_latency_seconds_bucket{cache="HIT",le="2.5",method="GET",status="200"} 130.0
    request_latency_seconds_bucket{cache="HIT",le="5.0",method="GET",status="200"} 130.0
    request_latency_seconds_bucket{cache="HIT",le="7.5",method="GET",status="200"} 130.0
    request_latency_seconds_bucket{cache="HIT",le="10.0",method="GET",status="200"} 130.0
    request_latency_seconds_bucket{cache="HIT",le="+Inf",method="GET",status="200"} 130.0
    request_latency_seconds_count{cache="HIT",method="GET",status="200"} 130.0
    request_latency_seconds_sum{cache="HIT",method="GET",status="200"} 76.75304985046387
    request_latency_seconds_bucket{cache="MISS",le="0.005",method="PATCH",status="200"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.01",method="PATCH",status="200"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.025",method="PATCH",status="200"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.05",method="PATCH",status="200"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.075",method="PATCH",status="200"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.1",method="PATCH",status="200"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.25",method="PATCH",status="200"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.5",method="PATCH",status="200"} 0.0
    request_latency_seconds_bucket{cache="MISS",le="0.75",method="PATCH",status="200"} 2.0
    request_latency_seconds_bucket{cache="MISS",le="1.0",method="PATCH",status="200"} 2.0
    request_latency_seconds_bucket{cache="MISS",le="2.5",method="PATCH",status="200"} 2.0
    request_latency_seconds_bucket{cache="MISS",le="5.0",method="PATCH",status="200"} 2.0
    request_latency_seconds_bucket{cache="MISS",le="7.5",method="PATCH",status="200"} 2.0
    request_latency_seconds_bucket{cache="MISS",le="10.0",method="PATCH",status="200"} 2.0
    request_latency_seconds_bucket{cache="MISS",le="+Inf",method="PATCH",status="200"} 2.0
    request_latency_seconds_count{cache="MISS",method="PATCH",status="200"} 2.0
    request_latency_seconds_sum{cache="MISS",method="PATCH",status="200"} 1.2275147438049316
    # TYPE request_latency_seconds_created gauge
    request_latency_seconds_created{cache="MISS",method="GET",status="404"} 1.5816881418340204e+09
    request_latency_seconds_created{cache="MISS",method="GET",status="200"} 1.5816881418628085e+09
    request_latency_seconds_created{cache="HIT",method="GET",status="200"} 1.5816881427032213e+09
    request_latency_seconds_created{cache="MISS",method="PATCH",status="200"} 1.5816882104669194e+09