### PR TITLE
Adding support for user validation

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -6,7 +6,8 @@ WORKDIR     /ghmirror
 
 COPY        . ./
 
-RUN         make develop
+RUN         pip install pipenv --upgrade
+RUN         pipenv install --dev
 
 ENTRYPOINT  ["make"]
 CMD         ["check"]

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all:
 
 
 prepare:
-	pip install pipenv --upgrade
+	pip install pipenv --user --upgrade
 
 install: prepare
 	pipenv install

--- a/README.md
+++ b/README.md
@@ -103,3 +103,17 @@ Run the development server:
 ```
 $  make run
 ```
+
+## User Validation
+
+To enable the user validation, the `GITHUB_USERS` environment variable
+should be available to the server. The `GITHUB_USERS` is a colon-separated
+list of authorized users to have their requests to the Github Mirror served.
+
+The user validation, when enabled, will not allow unauthenticated requests
+to the Github Mirror.
+
+Please notice that, in order to validate the user, one additional get request
+is made to the Github API, to the `/user` endpoint, using the provided
+authorization token. That call will also go through the caching mechanism, so
+the rate limit will be preserved when possible.

--- a/ghmirror/app/__init__.py
+++ b/ghmirror/app/__init__.py
@@ -26,6 +26,7 @@ from prometheus_client import generate_latest
 
 from ghmirror.app.response import MirrorResponse
 from ghmirror.data_structures.monostate import RequestsCache
+from ghmirror.core.constants import GH_API
 from ghmirror.data_structures.monostate import StatsCache
 from ghmirror.decorators.metrics import requests_metrics
 
@@ -34,7 +35,6 @@ logging.basicConfig(level=logging.INFO,
                     format='%(asctime)-15s %(message)s')
 
 LOG = logging.getLogger(__name__)
-GH_API = 'https://api.github.com'
 
 APP = flask.Flask(__name__)
 

--- a/ghmirror/core/constants.py
+++ b/ghmirror/core/constants.py
@@ -1,3 +1,17 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2020
+# Author: Amador Pahim <apahim@redhat.com>
+
 """
 System constants.
 """

--- a/ghmirror/core/constants.py
+++ b/ghmirror/core/constants.py
@@ -1,0 +1,5 @@
+"""
+System constants.
+"""
+
+GH_API = 'https://api.github.com'

--- a/ghmirror/core/mirror_requests.py
+++ b/ghmirror/core/mirror_requests.py
@@ -1,0 +1,86 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2020
+# Author: Amador Pahim <apahim@redhat.com>
+
+"""
+Implements conditional requests
+"""
+
+import hashlib
+import logging
+
+import requests
+
+from ghmirror.data_structures.monostate import RequestsCache
+from ghmirror.decorators.metrics import requests_metrics
+
+
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)-15s %(message)s')
+LOG = logging.getLogger(__name__)
+
+
+@requests_metrics
+def conditional_request(method, url, auth, data=None):
+    """
+    Implements conditional requests
+    """
+    cache = RequestsCache()
+    headers = {}
+    if auth is None:
+        auth_sha = None
+    else:
+        auth_sha = hashlib.sha1(auth.encode()).hexdigest()
+        headers['Authorization'] = auth
+
+    # Special case for non-GET requests
+    if method != 'GET':
+        # Just forward the request with the auth header
+        resp = requests.request(method=method,
+                                url=url,
+                                headers=headers,
+                                data=data)
+
+        LOG.info('[%s] CACHE_MISS %s', method, url)
+        # And just forward the response (with the
+        # cache-miss header, for metrics)
+        resp.headers['X-Cache'] = 'MISS'
+        return resp
+
+    cache_key = (url, auth_sha)
+
+    cached_response = None
+    if cache_key in cache:
+        cached_response = cache[cache_key]
+        etag = cached_response.headers.get('ETag')
+        if etag is not None:
+            headers['If-None-Match'] = etag
+        last_mod = cached_response.headers.get('Last-Modified')
+        if last_mod is not None:
+            headers['If-Modified-Since'] = last_mod
+
+    resp = requests.request(method=method, url=url, headers=headers)
+
+    if resp.status_code == 304:
+        LOG.info('[GET] CACHE_HIT %s', url)
+        cached_response.headers['X-Cache'] = 'HIT'
+        return cached_response
+
+    LOG.info('[GET] CACHE_MISS %s', url)
+    resp.headers['X-Cache'] = 'MISS'
+    # Caching only makes sense when at least one
+    # of those headers is present
+    if any(['ETag' in resp.headers,
+            'Last-Modified' in resp.headers]):
+        cache[cache_key] = resp
+    return resp

--- a/ghmirror/core/mirror_response.py
+++ b/ghmirror/core/mirror_response.py
@@ -32,9 +32,8 @@ class MirrorResponse:
     :type gh_api_url: str
     :type gh_mirror_url: str
     """
-    def __init__(self, original_response, headers, gh_api_url, gh_mirror_url):
+    def __init__(self, original_response, gh_api_url, gh_mirror_url):
         self._original_response = original_response
-        self._headers = headers
         self._gh_api_url = gh_api_url.rstrip('/')
         self._gh_mirror_url = gh_mirror_url.rstrip('/')
 
@@ -48,7 +47,11 @@ class MirrorResponse:
         :return: the sanitized headers
         :rtype: dict
         """
-        sanitized_headers = self._headers
+        sanitized_headers = dict()
+
+        x_cache = self._original_response.headers.get('X-Cache')
+        if x_cache is not None:
+            sanitized_headers['X-Cache'] = x_cache
 
         link = self._original_response.headers.get('Link')
         if link is not None:

--- a/ghmirror/data_structures/monostate.py
+++ b/ghmirror/data_structures/monostate.py
@@ -22,7 +22,7 @@ from prometheus_client import Histogram
 from prometheus_client import ProcessCollector
 
 
-__all__ = ['RequestsCache', 'StatsCache']
+__all__ = ['RequestsCache', 'StatsCache', 'UsersCache']
 
 
 class RequestsCacheBorg:
@@ -59,6 +59,39 @@ class RequestsCache(RequestsCacheBorg):
 
     def __iter__(self):
         return iter(self._data)
+
+
+class UsersCacheBorg:
+    """
+    Monostate class for sharing the users cache.
+    """
+    _state = {}
+
+    def __init__(self):
+        self.__dict__ = self._state
+
+
+class UsersCache(UsersCacheBorg):
+    """
+    Set-like implementation for caching users information.
+    """
+    def __getattr__(self, item):
+        """
+        Safe class argument initialization. We do it here
+        (instead of in the __init__()) so we don't overwrite
+        them when a new instance is created.
+        """
+        setattr(self, item, set())
+        return getattr(self, item)
+
+    def __contains__(self, item):
+        return item in self._data
+
+    def add(self, value):
+        """
+        Adding the value to the backing set
+        """
+        self._data.add(value)
 
 
 class StatsCacheBorg:

--- a/ghmirror/decorators/checks.py
+++ b/ghmirror/decorators/checks.py
@@ -1,0 +1,81 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2020
+# Author: Amador Pahim <apahim@redhat.com>
+
+"""
+Contains all the required verification
+"""
+
+import hashlib
+import os
+
+from functools import wraps
+
+import flask
+
+from ghmirror.core.constants import GH_API
+from ghmirror.core.mirror_requests import conditional_request
+from ghmirror.data_structures.monostate import UsersCache
+
+
+AUTHORIZED_USERS = os.environ.get('GITHUB_USERS')
+
+
+def check_user(function):
+    """
+    Checks whether the user is a member of one of the
+    authorized organizations
+    """
+    @wraps(function)
+    def wrapper(*args, **kwargs):
+        # When the GITHUB_USERS is not set, we resume the normal
+        # operation, where we do not check users
+        if AUTHORIZED_USERS is None:
+            return function(*args, **kwargs)
+
+        authorized_users = AUTHORIZED_USERS.split(':')
+        authorization = flask.request.headers.get('Authorization')
+        # At this stage, Authorization header is mandatory
+        if authorization is None:
+            return flask.Response('Requires authentication', 401)
+
+        users_cache = UsersCache()
+        auth_sha = hashlib.sha1(authorization.encode()).hexdigest()
+        # Users in cache were already checked and authorized,
+        # so we just keep serving them
+        if auth_sha in users_cache:
+            return function(*args, **kwargs)
+
+        # Using the Authorization header to get the user information
+        user_url = f'{GH_API}/user'
+        resp = conditional_request(method='GET', url=user_url,
+                                   auth=authorization)
+
+        # Fail early when Github API tells something is wrong
+        if resp.status_code != 200:
+            return flask.Response(resp.content, resp.status_code)
+
+        user_login = resp.json()['login']
+        # At this point we have the authorized_users list and the
+        # user login from Github. If there's a match, we just
+        # return the decorated function, but not before caching
+        # the user for the next time
+        if user_login in authorized_users:
+            users_cache.add(auth_sha)
+            return function(*args, **kwargs)
+
+        # No match means user is forbidden
+        return flask.Response('You have no permission to use '
+                              'the github-mirror', 403)
+
+    return wrapper

--- a/openshift/github-mirror.yaml
+++ b/openshift/github-mirror.yaml
@@ -29,6 +29,10 @@ objects:
         - image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always
           name: github-mirror
+          env:
+            - name: GITHUB_USERS
+              # Colon-separated list of authorized users
+              value: app-sre-bot
           ports:
           - name: github-mirror
             containerPort: 8080

--- a/tests/unit/test_reponse.py
+++ b/tests/unit/test_reponse.py
@@ -1,4 +1,4 @@
-from ghmirror.app.response import MirrorResponse
+from ghmirror.core.mirror_response import MirrorResponse
 
 
 class MockResponse:
@@ -25,7 +25,6 @@ class TestResponse:
                                      headers=headers,
                                      status_code=200)
         response = MirrorResponse(original_response=mock_response,
-                                  headers={},
                                   gh_api_url='foo',
                                   gh_mirror_url='bar')
 
@@ -43,7 +42,6 @@ class TestResponse:
                                      status_code=200)
 
         response = MirrorResponse(original_response=mock_response,
-                                  headers={},
                                   gh_api_url='foo',
                                   gh_mirror_url='bar')
 
@@ -68,8 +66,6 @@ class TestResponse:
                                      status_code=200)
 
         response = MirrorResponse(original_response=mock_response,
-                                  headers={},
-
                                   gh_api_url='foo',
                                   gh_mirror_url='bar')
 
@@ -83,7 +79,6 @@ class TestResponse:
                                      status_code=200)
 
         response = MirrorResponse(original_response=mock_response,
-                                  headers={},
                                   gh_api_url='foo',
                                   gh_mirror_url='bar')
 


### PR DESCRIPTION
When the `GITHUB_USERS` environment variable is present, the user
validation will be enabled. The `GITHUB_USERS` has to carry a list of
colon-separated user names that will have their requests served.