### PR TITLE
[APPSRE-1776] Fix url rewrite

### DIFF
--- a/ghmirror/app/__init__.py
+++ b/ghmirror/app/__init__.py
@@ -17,6 +17,7 @@ The GitHub Mirror endpoints
 """
 
 import logging
+import os
 
 import flask
 
@@ -75,9 +76,10 @@ def ghmirror(path):
                                auth=flask.request.headers.get('Authorization'),
                                data=flask.request.data)
 
+    gh_mirror_url = os.environ.get('GITHUB_MIRROR_URL', flask.request.host_url)
     mirror_response = MirrorResponse(original_response=resp,
                                      gh_api_url=GH_API,
-                                     gh_mirror_url=flask.request.host_url)
+                                     gh_mirror_url=gh_mirror_url)
 
     return flask.Response(mirror_response.content,
                           mirror_response.status_code,

--- a/openshift/github-mirror.yaml
+++ b/openshift/github-mirror.yaml
@@ -92,5 +92,9 @@ parameters:
   value: 500m
 - name: CPU_LIMIT
   value: 1000m
+# These values are meant to be overridden by the
+# saas-herder parametrization
 - name: GITHUB_USERS
   value: app-sre-bot:cs-sre-bot
+- name: GITHUB_MIRROR_URL
+  value: https://github-mirror.stage.devshift.net


### PR DESCRIPTION
The github api url is replaced by the github mirror url, but we can't
always probe the service url from within the service, specially when
we run the service without SSL and there's a Route facing the word which
implements SSL for us.

This fix allow us to specify the actual URL for the service, while still
trying our best to probe when the URL is not specified.

Signed-off-by: Amador Pahim <apahim@redhat.com>