### PR TITLE
Gihub Mirror Offline Mode

### DIFF
--- a/ghmirror/app/__init__.py
+++ b/ghmirror/app/__init__.py
@@ -38,6 +38,18 @@ logging.basicConfig(level=logging.INFO,
 APP = flask.Flask(__name__)
 
 
+def error_handler(exception):
+    """
+    Used when an exception happens in the flask app.
+    """
+    return flask.jsonify(message=f'Error reaching {GH_API}: '
+                                 f'{str(exception.__class__.__name__)}'), 502
+
+
+APP.config['TRAP_HTTP_EXCEPTIONS'] = True
+APP.register_error_handler(Exception, error_handler)
+
+
 @APP.route('/healthz', methods=["GET"])
 def healthz():
     """

--- a/ghmirror/app/__init__.py
+++ b/ghmirror/app/__init__.py
@@ -35,8 +35,6 @@ from ghmirror.decorators.checks import check_user
 logging.basicConfig(level=logging.INFO,
                     format='%(asctime)-15s %(message)s')
 
-LOG = logging.getLogger(__name__)
-
 APP = flask.Flask(__name__)
 
 

--- a/ghmirror/core/constants.py
+++ b/ghmirror/core/constants.py
@@ -17,3 +17,4 @@ System constants.
 """
 
 GH_API = 'https://api.github.com'
+REQUESTS_TIMEOUT = 1

--- a/ghmirror/core/mirror_requests.py
+++ b/ghmirror/core/mirror_requests.py
@@ -21,6 +21,7 @@ import logging
 
 import requests
 
+from ghmirror.core.constants import REQUESTS_TIMEOUT
 from ghmirror.data_structures.monostate import RequestsCache
 from ghmirror.decorators.metrics import requests_metrics
 
@@ -49,7 +50,8 @@ def conditional_request(method, url, auth, data=None):
         resp = requests.request(method=method,
                                 url=url,
                                 headers=headers,
-                                data=data)
+                                data=data,
+                                timeout=REQUESTS_TIMEOUT)
 
         LOG.info('[%s] CACHE_MISS %s', method, url)
         # And just forward the response (with the
@@ -69,7 +71,8 @@ def conditional_request(method, url, auth, data=None):
         if last_mod is not None:
             headers['If-Modified-Since'] = last_mod
 
-    resp = requests.request(method=method, url=url, headers=headers)
+    resp = requests.request(method=method, url=url, headers=headers,
+                            timeout=REQUESTS_TIMEOUT)
 
     if resp.status_code == 304:
         LOG.info('[GET] CACHE_HIT %s', url)

--- a/ghmirror/core/mirror_requests.py
+++ b/ghmirror/core/mirror_requests.py
@@ -23,6 +23,7 @@ import requests
 
 from ghmirror.core.constants import REQUESTS_TIMEOUT
 from ghmirror.data_structures.monostate import RequestsCache
+from ghmirror.data_structures.monostate import GithubStatus
 from ghmirror.decorators.metrics import requests_metrics
 
 
@@ -34,7 +35,18 @@ LOG = logging.getLogger(__name__)
 @requests_metrics
 def conditional_request(method, url, auth, data=None):
     """
-    Implements conditional requests
+    Implements conditional requests, checking first whether
+    the upstream API is online of offline to decide which
+    request routine to call.
+    """
+    if GithubStatus().online:
+        return online_request(method, url, auth, data)
+    return offline_request(method, url, auth)
+
+
+def online_request(method, url, auth, data=None):
+    """
+    Implements conditional requests.
     """
     cache = RequestsCache()
     headers = {}
@@ -53,10 +65,10 @@ def conditional_request(method, url, auth, data=None):
                                 data=data,
                                 timeout=REQUESTS_TIMEOUT)
 
-        LOG.info('[%s] CACHE_MISS %s', method, url)
+        LOG.info('ONLINE %s CACHE_MISS %s', method, url)
         # And just forward the response (with the
         # cache-miss header, for metrics)
-        resp.headers['X-Cache'] = 'MISS'
+        resp.headers['X-Cache'] = 'ONLINE_MISS'
         return resp
 
     cache_key = (url, auth_sha)
@@ -75,15 +87,61 @@ def conditional_request(method, url, auth, data=None):
                             timeout=REQUESTS_TIMEOUT)
 
     if resp.status_code == 304:
-        LOG.info('[GET] CACHE_HIT %s', url)
-        cached_response.headers['X-Cache'] = 'HIT'
+        LOG.info('ONLINE GET CACHE_HIT %s', url)
+        cached_response.headers['X-Cache'] = 'ONLINE_HIT'
         return cached_response
 
-    LOG.info('[GET] CACHE_MISS %s', url)
-    resp.headers['X-Cache'] = 'MISS'
+    LOG.info('ONLINE GET CACHE_MISS %s', url)
+    resp.headers['X-Cache'] = 'ONLINE_MISS'
     # Caching only makes sense when at least one
     # of those headers is present
     if any(['ETag' in resp.headers,
             'Last-Modified' in resp.headers]):
         cache[cache_key] = resp
     return resp
+
+
+def offline_request(method, url, auth):
+    """
+    Implements offline requests (serves content from cache, when possible).
+    """
+    headers = {}
+    if auth is None:
+        auth_sha = None
+    else:
+        auth_sha = hashlib.sha1(auth.encode()).hexdigest()
+        headers['Authorization'] = auth
+
+    # Special case for non-GET requests
+    if method != 'GET':
+        LOG.info('OFFLINE %s CACHE_MISS %s', method, url)
+        # Not much to do here. We just build up a response
+        # with a reasonable status code so users know that our
+        # upstream is offline
+        response = requests.models.Response()
+        response.status_code = 504
+        response.headers['X-Cache'] = 'OFFLINE_MISS'
+        # pylint: disable=protected-access
+        response._content = b'{\n  "message": "gateway timeout"\n}\n'
+        return response
+
+    cache = RequestsCache()
+    cache_key = (url, auth_sha)
+    if cache_key in cache:
+        LOG.info('OFFLINE GET CACHE_HIT %s', url)
+        # This is the best case: upstream is offline
+        # but we have the resource in cache for a given
+        # user. We then serve from cache.
+        cached_response = cache[cache_key]
+        cached_response.headers['X-Cache'] = 'OFFLINE_HIT'
+        return cached_response
+
+    LOG.info('OFFLINE GET CACHE_MISS %s', url)
+    # GETs without cached content will receive an error
+    # code so they know our upstream is offline.
+    response = requests.models.Response()
+    response.status_code = 504
+    response.headers['X-Cache'] = 'OFFLINE_MISS'
+    # pylint: disable=protected-access
+    response._content = b'{\n  "message": "gateway timeout"\n}\n'
+    return response

--- a/ghmirror/core/mirror_response.py
+++ b/ghmirror/core/mirror_response.py
@@ -83,6 +83,9 @@ class MirrorResponse:
         :return: the sanitized content
         :rtype: bytes
         """
+        if self._original_response.content is None:
+            return None
+
         sanitized_content = self._original_response.content.replace(
             self._gh_api_url.encode(),
             self._gh_mirror_url.encode()

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -5,6 +5,7 @@ import pytest
 
 from ghmirror.app import APP
 from ghmirror.data_structures.monostate import UsersCache
+from ghmirror.core.constants import REQUESTS_TIMEOUT
 
 
 class MockResponse:
@@ -147,7 +148,8 @@ def test_mirror_upstream_call(mocked_request, client):
     expected_url = 'https://api.github.com/user/repos?page=2'
     mocked_request.assert_called_with(method='GET',
                                       headers={'Authorization': 'foo'},
-                                      url=expected_url)
+                                      url=expected_url,
+                                      timeout=REQUESTS_TIMEOUT)
 
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
@@ -156,7 +158,8 @@ def test_mirror_non_get(mocked_request, client):
     client.patch('/repos/foo/bar', data=b'foo')
     expected_url = 'https://api.github.com/repos/foo/bar'
     mocked_request.assert_called_with(method='PATCH', data=b'foo', headers={},
-                                      url=expected_url)
+                                      url=expected_url,
+                                      timeout=REQUESTS_TIMEOUT)
 
 
 @mock.patch('ghmirror.decorators.checks.AUTHORIZED_USERS', 'app-sre-bot')
@@ -171,7 +174,8 @@ def test_mirror_authorized_user(mocked_request, mocked_cond_request, client):
     mocked_request.assert_called_with(method='GET',
                                       headers={'Authorization': 'foo'},
                                       url='https://api.github.com/repos/'
-                                          'app-sre/github-mirror')
+                                          'app-sre/github-mirror',
+                                      timeout=REQUESTS_TIMEOUT)
 
 
 @mock.patch('ghmirror.decorators.checks.AUTHORIZED_USERS', 'app-sre-bot')
@@ -190,7 +194,8 @@ def test_mirror_authorized_user_cached(mocked_request, mocked_cond_request,
     mocked_request.assert_called_with(method='GET',
                                       headers={'Authorization': 'foo'},
                                       url='https://api.github.com/repos/'
-                                          'app-sre/github-mirror')
+                                          'app-sre/github-mirror',
+                                      timeout=REQUESTS_TIMEOUT)
 
 
 @mock.patch('ghmirror.decorators.checks.AUTHORIZED_USERS', 'app-sre-bot')

--- a/tests/unit/test_reponse.py
+++ b/tests/unit/test_reponse.py
@@ -3,7 +3,10 @@ from ghmirror.core.mirror_response import MirrorResponse
 
 class MockResponse:
     def __init__(self, content, headers, status_code):
-        self.content = content.encode()
+        if content is None:
+            self.content = content
+        else:
+            self.content = content.encode()
         self.headers = headers
         self.status_code = status_code
 
@@ -61,14 +64,23 @@ class TestResponse:
         assert not response_headers
 
     def test_content(self):
-        mock_response = MockResponse(content='foobar',
+        mock_response = MockResponse(content=None,
                                      headers={},
                                      status_code=200)
 
         response = MirrorResponse(original_response=mock_response,
                                   gh_api_url='foo',
                                   gh_mirror_url='bar')
+        # No content from the upstream response should stay the
+        # same in the mirror response
+        assert response.content == None
 
+        mock_response = MockResponse(content='foobar',
+                                     headers={},
+                                     status_code=200)
+        response = MirrorResponse(original_response=mock_response,
+                                  gh_api_url='foo',
+                                  gh_mirror_url='bar')
         # content should have been modified, replacing the
         # gh_api_url string by the gh_mirror_url string.
         assert response.content == 'barbar'.encode()


### PR DESCRIPTION
Logs:
```
2020-06-29 20:13:04,399 ONLINE GET CACHE_MISS https://api.github.com/repos/app-sre/sretoolbox
2020-06-29 20:13:09,619 ONLINE GET CACHE_HIT https://api.github.com/repos/app-sre/sretoolbox
2020-06-29 20:13:20,392 ONLINE GET CACHE_HIT https://api.github.com/repos/app-sre/sretoolbox
2020-06-29 20:13:31,548 OFFLINE GET CACHE_HIT https://api.github.com/repos/app-sre/sretoolbox
2020-06-29 20:13:45,170 OFFLINE GET CACHE_HIT https://api.github.com/repos/app-sre/sretoolbox
2020-06-29 20:13:46,191 OFFLINE GET CACHE_HIT https://api.github.com/repos/app-sre/sretoolbox
2020-06-29 20:13:47,074 OFFLINE GET CACHE_HIT https://api.github.com/repos/app-sre/sretoolbox
2020-06-29 20:14:03,274 ONLINE GET CACHE_HIT https://api.github.com/repos/app-sre/sretoolbox
```

Metrics:
```
request_latency_seconds_count{cache="ONLINE_MISS",method="GET",status="200"} 1.0
request_latency_seconds_count{cache="ONLINE_HIT",method="GET",status="200"} 3.0
request_latency_seconds_count{cache="OFFLINE_HIT",method="GET",status="200"} 4.0
```