### PR TITLE
Relax timeouts

### DIFF
--- a/ghmirror/core/constants.py
+++ b/ghmirror/core/constants.py
@@ -17,4 +17,5 @@ System constants.
 """
 
 GH_API = 'https://api.github.com'
-REQUESTS_TIMEOUT = 1
+REQUESTS_TIMEOUT = 10
+STATUS_TIMEOUT = 2

--- a/ghmirror/data_structures/monostate.py
+++ b/ghmirror/data_structures/monostate.py
@@ -31,7 +31,7 @@ from prometheus_client import Histogram
 from prometheus_client import ProcessCollector
 
 from ghmirror.core.constants import GH_API
-from ghmirror.core.constants import REQUESTS_TIMEOUT
+from ghmirror.core.constants import STATUS_TIMEOUT
 
 
 __all__ = ['GithubStatus', 'RequestsCache', 'StatsCache', 'UsersCache']
@@ -61,7 +61,7 @@ class _GithubStatus:
         while True:
             try:
                 response = requests.get(f'{GH_API}/status',
-                                        timeout=REQUESTS_TIMEOUT)
+                                        timeout=STATUS_TIMEOUT)
                 response.raise_for_status()
                 self.online = True
             except (requests.exceptions.ConnectionError,


### PR DESCRIPTION
1s is proving to be too tight. Let's give 10s to the client requests and
2s for our status check thread.

Signed-off-by: Amador Pahim <apahim@redhat.com>