### PR TITLE
Fix race condition in tests

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,4 @@
 [MESSAGES CONTROL]
 disable = too-few-public-methods,
           no-member,
+          too-many-arguments,

--- a/ghmirror/utils/wait.py
+++ b/ghmirror/utils/wait.py
@@ -1,0 +1,31 @@
+"""
+Functions to help waiting for a given state
+"""
+import time
+
+
+def wait_for(func, timeout, first=0.0, step=1.0, args=None, kwargs=None):
+    """
+    Wait until func() evaluates to True.
+
+    If func() evaluates to True before timeout expires, return the
+    value of func(). Otherwise return None.
+
+    :param timeout: Timeout in seconds
+    :param first: Time to sleep before first attempt
+    :param step: Time to sleep between attempts in seconds
+    :param args: Positional arguments to func
+    :param kwargs: Keyword arguments to func
+    """
+    if args is None:
+        args = []
+    if kwargs is None:
+        kwargs = {}
+    start_time = time.monotonic()
+    end_time = start_time + timeout
+    time.sleep(first)
+    while time.monotonic() < end_time:
+        result = func(*args, **kwargs)
+        if result:
+            return result
+        time.sleep(step)


### PR DESCRIPTION
The thread checking the mirror state could go offline before we make the
first call to build up the cache.

This patch adds more control to when the mirror goes offline/online,
mitigating the race condition.

Signed-off-by: Amador Pahim <apahim@redhat.com>