### PR TITLE
On api rate limit, use the offline flow

### DIFF
--- a/tests/unit/test_requests.py
+++ b/tests/unit/test_requests.py
@@ -5,7 +5,9 @@ from random import randint
 from ghmirror.data_structures.requests_cache import RequestsCache
 from ghmirror.data_structures.monostate import StatsCache
 
-RAND_CACHE_SIZE = randint(100,1000)
+
+RAND_CACHE_SIZE = randint(100, 1000)
+
 
 class TestStatsCache:
 
@@ -73,12 +75,12 @@ class MockRedis:
     def info(self):
         return {'used_memory': self.size}
 
+
 def mocked_redis_cache(*args, **kwargs):
     return MockRedis(size=RAND_CACHE_SIZE)
 
 
 class TestRequestsCache(TestCase):
-
 
     @mock.patch('ghmirror.data_structures.requests_cache.CACHE_TYPE', 'redis')
     @mock.patch(


### PR DESCRIPTION
When the API rate limit takes place, let's try to serve from cache
so users will be impacted as little as possible.

Signed-off-by: Amador Pahim <apahim@redhat.com>