### PR TITLE
Specific metrics for rate limited state

### DIFF
--- a/ghmirror/core/mirror_requests.py
+++ b/ghmirror/core/mirror_requests.py
@@ -93,9 +93,13 @@ def online_request(method, url, auth, data=None):
 
     # When wen hit the API limit, let's try to serve from cache
     if resp.status_code == 403 and 'API rate limit exceeded' in resp.text:
-        return offline_request(method=method, url=url, auth=auth,
-                               error_code=resp.status_code,
-                               error_message=resp.content)
+        if cached_response is None:
+            LOG.info('RATE_LIMITED GET CACHE_MISS %s', url)
+            resp.headers['X-Cache'] = 'RATE_LIMITED_MISS'
+            return resp
+        LOG.info('RATE_LIMITED GET CACHE_HIT %s', url)
+        cached_response.headers['X-Cache'] = 'RATE_LIMITED_HIT'
+        return cached_response
 
     LOG.info('ONLINE GET CACHE_MISS %s', url)
     resp.headers['X-Cache'] = 'ONLINE_MISS'

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -339,9 +339,9 @@ def test_rate_limited(mock_monitor_get, mock_request, client):
     response = client.get('/repos/app-sre/github-mirror')
     assert response.status_code == 403
     response = client.get('/metrics')
-    # In the metrics, we see an OFFLINE_HIT
+    # In the metrics, we see a RATE_LIMITED_MISS
     assert response.status_code == 200
-    assert ('request_latency_seconds_count{cache="OFFLINE_MISS",'
+    assert ('request_latency_seconds_count{cache="RATE_LIMITED_MISS",'
             'method="GET",status="403"} 1.0') in str(response.data)
 
     # Second request will be a 200, intended to build up the cache, so
@@ -354,13 +354,13 @@ def test_rate_limited(mock_monitor_get, mock_request, client):
     assert ('request_latency_seconds_count{cache="ONLINE_MISS",'
             'method="GET",status="200"} 1.0') in str(response.data)
 
-    # For the Third request, the response is a 403/rate-limited,
+    # For the third request, the response is a 403/rate-limited,
     # but because the resource was cached we want to see a 200
-    # with OFFLINE_HIT
+    # with RATE_LIMITED_HIT
     mock_request.side_effect = mocked_requests_rate_limited
     response = client.get('/repos/app-sre/github-mirror')
     assert response.status_code == 200
     response = client.get('/metrics')
     assert response.status_code == 200
-    assert ('request_latency_seconds_count{cache="OFFLINE_HIT",'
+    assert ('request_latency_seconds_count{cache="RATE_LIMITED_HIT",'
             'method="GET",status="200"} 1.0') in str(response.data)


### PR DESCRIPTION
This feature was originally introduced hooking into the offline
flow, but that has the side effect of making hard to diferentiate
those from the real offline mode.

This patch removes the need for using the offline flow for serving
requests from cache when we are being rate limited. With that,
we have now a new metric cache="RATE_LIMITED_MISS/HIT" so we can generate
independent graphs.

Signed-off-by: Amador Pahim <apahim@redhat.com>