### PR TITLE
set PER_PAGE_ELEMENTS 100 -> 30

### DIFF
--- a/ghmirror/core/constants.py
+++ b/ghmirror/core/constants.py
@@ -19,4 +19,4 @@ System constants.
 GH_API = 'https://api.github.com'
 REQUESTS_TIMEOUT = 10
 STATUS_TIMEOUT = 2
-PER_PAGE_ELEMENTS = 100
+PER_PAGE_ELEMENTS = 30


### PR DESCRIPTION
follows up on #57, #59

30 is the GH default, and we believe setting this to 100 leads to an increase in latency.