### PR TITLE
Appsre 3576 Try to serve API errors from Cache

### DIFF
--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -178,7 +178,8 @@ def test_mirror_upstream_call(mocked_request, client):
                                       headers={'Authorization': 'foo'},
                                       url=expected_url,
                                       timeout=REQUESTS_TIMEOUT,
-                                      params={'page': '2', 'per_page': PER_PAGE_ELEMENTS})
+                                      params={'page': '2', 'per_page': PER_PAGE_ELEMENTS},
+                                      data=b'')
 
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
@@ -206,7 +207,8 @@ def test_mirror_authorized_user(mocked_request, mocked_cond_request, client):
                                       url='https://api.github.com/repos/'
                                           'app-sre/github-mirror',
                                       timeout=REQUESTS_TIMEOUT,
-                                      params={'per_page': PER_PAGE_ELEMENTS})
+                                      params={'per_page': PER_PAGE_ELEMENTS},
+                                      data=b'')
 
 
 @mock.patch('ghmirror.decorators.checks.AUTHORIZED_USERS', 'app-sre-bot')
@@ -227,7 +229,8 @@ def test_mirror_authorized_user_cached(mocked_request, mocked_cond_request,
                                       url='https://api.github.com/repos/'
                                           'app-sre/github-mirror',
                                       timeout=REQUESTS_TIMEOUT,
-                                      params={'per_page': PER_PAGE_ELEMENTS})
+                                      params={'per_page': PER_PAGE_ELEMENTS},
+                                      data=b'')
 
 
 @mock.patch('ghmirror.decorators.checks.AUTHORIZED_USERS', 'app-sre-bot')

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -178,8 +178,7 @@ def test_mirror_upstream_call(mocked_request, client):
                                       headers={'Authorization': 'foo'},
                                       url=expected_url,
                                       timeout=REQUESTS_TIMEOUT,
-                                      params={'page': '2', 'per_page': PER_PAGE_ELEMENTS},
-                                      data=b'')
+                                      params={'page': '2', 'per_page': PER_PAGE_ELEMENTS})
 
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
@@ -207,8 +206,7 @@ def test_mirror_authorized_user(mocked_request, mocked_cond_request, client):
                                       url='https://api.github.com/repos/'
                                           'app-sre/github-mirror',
                                       timeout=REQUESTS_TIMEOUT,
-                                      params={'per_page': PER_PAGE_ELEMENTS},
-                                      data=b'')
+                                      params={'per_page': PER_PAGE_ELEMENTS})
 
 
 @mock.patch('ghmirror.decorators.checks.AUTHORIZED_USERS', 'app-sre-bot')
@@ -229,8 +227,7 @@ def test_mirror_authorized_user_cached(mocked_request, mocked_cond_request,
                                       url='https://api.github.com/repos/'
                                           'app-sre/github-mirror',
                                       timeout=REQUESTS_TIMEOUT,
-                                      params={'per_page': PER_PAGE_ELEMENTS},
-                                      data=b'')
+                                      params={'per_page': PER_PAGE_ELEMENTS})
 
 
 @mock.patch('ghmirror.decorators.checks.AUTHORIZED_USERS', 'app-sre-bot')
@@ -462,3 +459,139 @@ def test_pagination_corner_case(mock_get, client):
             'method="GET",status="200"}') not in str(response.data)
     assert ('request_latency_seconds_count{cache="ONLINE_MISS",'
             'method="GET",status="200"} 2.0') in str(response.data)
+
+
+@mock.patch('ghmirror.core.mirror_requests.requests.request',
+            side_effect=requests.exceptions.Timeout)
+def test_mirror_request_timeout(mock_get, client):
+    # Initially the stats are zeroed
+    response = client.get('/metrics')
+    assert response.status_code == 200
+    assert ('request_latency_seconds_count{cache="ONLINE_HIT",'
+            'method="GET",status="200"}') not in str(response.data)
+    assert ('request_latency_seconds_count{cache="ONLINE_MISS",'
+            'method="GET",status="200"}') not in str(response.data)
+
+    response = client.get('/repos/app-sre/github-mirror',
+                          follow_redirects=True)
+    assert response.status_code == 502
+    assert "Timeout" in response.data.decode("utf-8")
+
+
+@mock.patch('ghmirror.core.mirror_requests.requests.request',
+            side_effect=mocked_requests_get_etag)
+def test_mirror_request_timeout_hit(mock_get, client):
+    # Initially the stats are zeroed
+    response = client.get('/metrics')
+    assert response.status_code == 200
+    assert ('request_latency_seconds_count{cache="ONLINE_HIT",'
+            'method="GET",status="200"}') not in str(response.data)
+    assert ('request_latency_seconds_count{cache="ONLINE_MISS",'
+            'method="GET",status="200"}') not in str(response.data)
+
+    response = client.get('/repos/app-sre/github-mirror',
+                          follow_redirects=True)
+    assert response.status_code == 200
+
+    # First get is a cache_miss
+    response = client.get('/metrics', follow_redirects=True)
+
+    assert response.status_code == 200
+    assert ('request_latency_seconds_count{cache="ONLINE_HIT",'
+            'method="GET",status="200"}') not in str(response.data)
+    assert ('request_latency_seconds_count{cache="ONLINE_MISS",'
+            'method="GET",status="200"} 1.0') in str(response.data)
+
+    mock_get.side_effect = requests.exceptions.Timeout
+    response = client.get('/repos/app-sre/github-mirror',
+                          follow_redirects=True)
+    assert response.status_code == 200
+
+    # Second get is a cache_hit
+    response = client.get('/metrics', follow_redirects=True)
+
+    assert response.status_code == 200
+    assert ('request_latency_seconds_count{cache="API_TIMEOUT_HIT",'
+            'method="GET",status="200"} 1.0') in str(response.data)
+    assert ('request_latency_seconds_count{cache="ONLINE_MISS",'
+            'method="GET",status="200"} 1.0') in str(response.data)
+
+
+@mock.patch('ghmirror.core.mirror_requests.requests.request',
+            side_effect=mocked_requests_get_etag)
+def test_mirror_request_5xx(mock_get, client):
+    # Initially the stats are zeroed
+    response = client.get('/metrics')
+    assert response.status_code == 200
+    assert ('request_latency_seconds_count{cache="ONLINE_HIT",'
+            'method="GET",status="200"}') not in str(response.data)
+    assert ('request_latency_seconds_count{cache="ONLINE_MISS",'
+            'method="GET",status="200"}') not in str(response.data)
+
+    response = client.get('/repos/app-sre/github-mirror',
+                          follow_redirects=True)
+    assert response.status_code == 200
+
+    # First get is a cache_miss
+    response = client.get('/metrics', follow_redirects=True)
+
+    assert response.status_code == 200
+    assert ('request_latency_seconds_count{cache="ONLINE_HIT",'
+            'method="GET",status="200"}') not in str(response.data)
+    assert ('request_latency_seconds_count{cache="ONLINE_MISS",'
+            'method="GET",status="200"} 1.0') in str(response.data)
+
+
+    mock_get.side_effect = mocked_requests_get_error
+    response = client.get('/repos/app-sre/github-mirror',
+                          follow_redirects=True)
+    assert response.status_code == 200
+
+    # Second get is a cache_hit
+    response = client.get('/metrics', follow_redirects=True)
+
+    assert response.status_code == 200
+    assert ('request_latency_seconds_count{cache="API_ERROR_HIT",'
+            'method="GET",status="200"} 1.0') in str(response.data)
+    assert ('request_latency_seconds_count{cache="ONLINE_MISS",'
+            'method="GET",status="200"} 1.0') in str(response.data)
+
+
+@mock.patch('ghmirror.core.mirror_requests.requests.request',
+            side_effect=mocked_requests_get_etag)
+def test_mirror_request_5xx_miss(mock_get, client):
+    # Initially the stats are zeroed
+    response = client.get('/metrics')
+    assert response.status_code == 200
+    assert ('request_latency_seconds_count{cache="ONLINE_HIT",'
+            'method="GET",status="200"}') not in str(response.data)
+    assert ('request_latency_seconds_count{cache="ONLINE_MISS",'
+            'method="GET",status="200"}') not in str(response.data)
+
+    response = client.get('/repos/app-sre/github-mirror',
+                          follow_redirects=True)
+    assert response.status_code == 200
+
+    # First get is a cache_miss
+    response = client.get('/metrics', follow_redirects=True)
+
+    assert response.status_code == 200
+    assert ('request_latency_seconds_count{cache="ONLINE_HIT",'
+            'method="GET",status="200"}') not in str(response.data)
+    assert ('request_latency_seconds_count{cache="ONLINE_MISS",'
+            'method="GET",status="200"} 1.0') in str(response.data)
+
+
+    mock_get.side_effect = mocked_requests_get_error
+    response = client.get('/repos/app-sre/github-mirror/2',
+                          follow_redirects=True)
+    assert response.status_code == 500
+
+    # Second get is a cache_hit
+    response = client.get('/metrics', follow_redirects=True)
+
+    assert response.status_code == 200
+    assert ('request_latency_seconds_count{cache="API_ERROR_MISS",'
+            'method="GET",status="500"} 1.0') in str(response.data)
+    assert ('request_latency_seconds_count{cache="ONLINE_MISS",'
+            'method="GET",status="200"} 1.0') in str(response.data)

--- a/tests/unit/test_requests.py
+++ b/tests/unit/test_requests.py
@@ -181,8 +181,7 @@ class TestServeFromCacheCondition(TestCase):
                             headers={},
                             status_code=403,
                             text=text)
-        serve_from_cache, header = _should_error_response_be_served_from_cache(resp)
-        assert serve_from_cache is True
+        header = _should_error_response_be_served_from_cache(resp)
         assert header == "RATE_LIMITED"
 
     def test_should_serve_from_cache_api_error(self):
@@ -191,8 +190,7 @@ class TestServeFromCacheCondition(TestCase):
                             headers={},
                             status_code=500,
                             text=text)
-        serve_from_cache, header = _should_error_response_be_served_from_cache(resp)
-        assert serve_from_cache is True
+        header = _should_error_response_be_served_from_cache(resp)
         assert header == "API_ERROR"
 
     def test_should_serve_from_cache_ok(self):
@@ -201,6 +199,5 @@ class TestServeFromCacheCondition(TestCase):
                             headers={},
                             status_code=200,
                             text=text)
-        serve_from_cache, header = _should_error_response_be_served_from_cache(resp)
-        assert serve_from_cache is False
-        assert header == ""
+        header = _should_error_response_be_served_from_cache(resp)
+        assert header == None


### PR DESCRIPTION
This MR aims to handle Github API errors and try to return responses from the cache as part of APPSRE-3576