### PR TITLE
Use python 3.9 ubi8 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM        registry.access.redhat.com/ubi8/python-38
+FROM        registry.access.redhat.com/ubi8/python-39
 
 WORKDIR     /ghmirror
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM        registry.access.redhat.com/ubi8/python-38
+FROM        registry.access.redhat.com/ubi8/python-39
 
 USER        root
 


### PR DESCRIPTION
Updated base image for prod and test to registry.access.redhat.com/ubi8/python-39
pr_check and unit tests still work as expected

Refs APPSRE-3899