### PR TITLE
pylint fixes for tests

### DIFF
--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -79,8 +79,8 @@ def mocked_requests_api_corner_case(*_args, **kwargs):
 
     return MockResponse('', {'ETag': 'foo'}, 200, json_content=[{'a': 'b'}, {'c', 'd'}])
 
-@pytest.fixture
-def client():
+@pytest.fixture(name="client")
+def fixture_client():
     APP.config['TESTING'] = True
 
     with APP.test_client() as client:

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -31,7 +31,7 @@ class MockResponse:
             raise requests.exceptions.HTTPError
 
 
-def mocked_requests_get_etag(*args, **kwargs):
+def mocked_requests_get_etag(*_args, **kwargs):
     if 'If-Modified-Since' in kwargs['headers']:
         return MockResponse('', {}, 304)
 
@@ -41,7 +41,7 @@ def mocked_requests_get_etag(*args, **kwargs):
     return MockResponse('', {'ETag': 'foo'}, 200)
 
 
-def mocked_requests_get_last_modified(*args, **kwargs):
+def mocked_requests_get_last_modified(*_args, **kwargs):
     if 'If-Modified-Since' in kwargs['headers']:
         return MockResponse('', {}, 304)
 
@@ -51,33 +51,33 @@ def mocked_requests_get_last_modified(*args, **kwargs):
     return MockResponse('', {'Last-Modified': 'bar'}, 200)
 
 
-def mocked_requests_get_user_orgs_auth(*args, **kwargs):
+def mocked_requests_get_user_orgs_auth(*_args, **_kwargs):
     return MockResponse('', {}, 200, 'app-sre-bot')
 
 
-def mocked_requests_get_user_orgs_unauth(*args, **kwargs):
+def mocked_requests_get_user_orgs_unauth(*_args, **_kwargs):
     return MockResponse('', {}, 200, 'other')
 
 
-def mocked_requests_get_error(*args, **kwargs):
+def mocked_requests_get_error(*_args, **_kwargs):
     return MockResponse('', {}, 500)
 
 
-def mocked_requests_monitor_good(*args, **kwargs):
+def mocked_requests_monitor_good(*_args, **_kwargs):
     return MockResponse('', {}, 200)
 
 
-def mocked_requests_monitor_bad(*args, **kwargs):
+def mocked_requests_monitor_bad(*_args, **_kwargs):
     return MockResponse('', {}, 403)
 
-def mocked_requests_rate_limited(*args, **kwargs):
+def mocked_requests_rate_limited(*_args, **_kwargs):
     return MockResponse('API rate limit exceeded', {}, 403)
 
-def mocked_requests_api_corner_case(*args, **kwargs):
+def mocked_requests_api_corner_case(*_args, **kwargs):
     if 'If-None-Match' in kwargs['headers']:
         return MockResponse('', {}, 304, json_content=[{'a': 'b'}, {'c', 'd'}])
 
-    return MockResponse('', {'ETag': 'foo'} , 200, json_content=[{'a': 'b'}, {'c', 'd'}])
+    return MockResponse('', {'ETag': 'foo'}, 200, json_content=[{'a': 'b'}, {'c', 'd'}])
 
 @pytest.fixture
 def client():
@@ -95,7 +95,7 @@ def test_healthz(client):
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
             side_effect=mocked_requests_get_etag)
-def test_mirror_etag(mock_get, client):
+def test_mirror_etag(_mock_get, client):
     # Initially the stats are zeroed
     response = client.get('/metrics')
     assert response.status_code == 200
@@ -133,7 +133,7 @@ def test_mirror_etag(mock_get, client):
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
             side_effect=mocked_requests_get_last_modified)
-def test_mirror_last_modified(mock_get, client):
+def test_mirror_last_modified(_mock_get, client):
     # Initially the stats are zeroed
     response = client.get('/metrics')
     assert response.status_code == 200
@@ -233,7 +233,7 @@ def test_mirror_authorized_user_cached(mocked_request, mocked_cond_request,
 @mock.patch('ghmirror.decorators.checks.AUTHORIZED_USERS', 'app-sre-bot')
 @mock.patch('ghmirror.decorators.checks.conditional_request',
             side_effect=mocked_requests_get_user_orgs_unauth)
-def test_mirror_user_forbidden(mocked_cond_request, client):
+def test_mirror_user_forbidden(_mocked_cond_request, client):
     response = client.get('/repos/app-sre/github-mirror',
                           headers={'Authorization': 'foo'})
     assert response.status_code == 403
@@ -249,7 +249,7 @@ def test_mirror_no_auth(client):
 @mock.patch('ghmirror.decorators.checks.AUTHORIZED_USERS', 'app-sre-bot')
 @mock.patch('ghmirror.decorators.checks.conditional_request',
             side_effect=mocked_requests_get_error)
-def test_mirror_auth_error(mocked_cond_request, client):
+def test_mirror_auth_error(_mocked_cond_request, client):
     response = client.get('/repos/app-sre/github-mirror',
                           headers={'Authorization': 'foo'})
     assert response.status_code == 500
@@ -259,7 +259,7 @@ def test_mirror_auth_error(mocked_cond_request, client):
             side_effect=mocked_requests_get_etag)
 @mock.patch('ghmirror.data_structures.monostate.requests.get',
             side_effect=mocked_requests_monitor_good)
-def test_offline_mode(mock_monitor_get, mock_request, client):
+def test_offline_mode(mock_monitor_get, _mock_request, client):
     # Let's wait the mirror consider itself online
     assert wait_for(lambda: GithubStatus().online, timeout=5)
 
@@ -311,7 +311,7 @@ def test_offline_mode(mock_monitor_get, mock_request, client):
             side_effect=mocked_requests_get_etag)
 @mock.patch('ghmirror.data_structures.monostate.requests.get',
             side_effect=mocked_requests_monitor_good)
-def test_offline_mode_upstream_error(mock_monitor_get, mock_request, client):
+def test_offline_mode_upstream_error(mock_monitor_get, _mock_request, client):
     # Let's wait the mirror consider itself online
     assert wait_for(lambda: GithubStatus().online, timeout=5)
 
@@ -346,7 +346,7 @@ def test_offline_mode_upstream_error(mock_monitor_get, mock_request, client):
             side_effect=mocked_requests_rate_limited)
 @mock.patch('ghmirror.data_structures.monostate.requests.get',
             side_effect=mocked_requests_monitor_good)
-def test_rate_limited(mock_monitor_get, mock_request, client):
+def test_rate_limited(_mock_monitor_get, mock_request, client):
     # First request will get a 403/rate-limited. Because it's not cached
     # yet, we receive the same 403
     response = client.get('/repos/app-sre/github-mirror')
@@ -381,7 +381,7 @@ def test_rate_limited(mock_monitor_get, mock_request, client):
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
             side_effect=mocked_requests_api_corner_case)
-def test_pagination_corner_case_custom_page_elements(mock_get, client):
+def test_pagination_corner_case_custom_page_elements(_mock_get, client):
     # Initially the stats are zeroed
     response = client.get('/metrics')
     assert response.status_code == 200
@@ -422,7 +422,7 @@ def test_pagination_corner_case_custom_page_elements(mock_get, client):
 @mock.patch('ghmirror.core.mirror_requests.PER_PAGE_ELEMENTS', 2)
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
             side_effect=mocked_requests_api_corner_case)
-def test_pagination_corner_case(mock_get, client):
+def test_pagination_corner_case(_mock_get, client):
     # Initially the stats are zeroed
     response = client.get('/metrics')
     assert response.status_code == 200
@@ -431,9 +431,8 @@ def test_pagination_corner_case(mock_get, client):
     assert ('request_latency_seconds_count{cache="ONLINE_MISS",'
             'method="GET",status="200"}') not in str(response.data)
 
-
     response = client.get('/repos/app-sre/github-mirror',
-                        follow_redirects=True)
+                          follow_redirects=True)
     assert response.status_code == 200
 
     # First get is a cache_miss
@@ -463,7 +462,7 @@ def test_pagination_corner_case(mock_get, client):
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
             side_effect=requests.exceptions.Timeout)
-def test_mirror_request_timeout(mock_get, client):
+def test_mirror_request_timeout(_mock_get, client):
     # Initially the stats are zeroed
     response = client.get('/metrics')
     assert response.status_code == 200

--- a/tests/unit/test_reponse.py
+++ b/tests/unit/test_reponse.py
@@ -1,3 +1,5 @@
+from unittest import TestCase
+
 from ghmirror.core.mirror_response import MirrorResponse
 
 
@@ -11,7 +13,7 @@ class MockResponse:
         self.status_code = status_code
 
 
-class TestResponse:
+class TestResponse(TestCase):
 
     def test_no_headers(self):
         headers = {'Some-Other-Header': 'foo'}
@@ -23,7 +25,7 @@ class TestResponse:
                                   gh_mirror_url='bar')
 
         # That item should not be part of the response.headers
-        assert not response.headers
+        self.assertFalse(response.headers)
 
     def test_headers(self):
         headers = {'Link': 'foobar',
@@ -44,15 +46,15 @@ class TestResponse:
         link = response_headers.pop('Link')
         # Link should have been modified, replacing the gh_api_url string
         # by the gh_mirror_url string.
-        assert link == 'barbar'
+        self.assertEqual(link, 'barbar')
 
         # Those headers should be there
         for item in ['Content-Type', 'Last-Modified', 'ETag']:
             header = response_headers.pop(item)
-            assert header == 'foo'
+            self.assertEqual(header, 'foo')
 
         # No other headers should be there
-        assert not response_headers
+        self.assertFalse(response_headers)
 
     def test_content(self):
         mock_response = MockResponse(content=None,
@@ -64,7 +66,7 @@ class TestResponse:
                                   gh_mirror_url='bar')
         # No content from the upstream response should stay the
         # same in the mirror response
-        assert response.content is None
+        self.assertIsNone(response.content)
 
         mock_response = MockResponse(content='foobar',
                                      headers={},
@@ -74,7 +76,7 @@ class TestResponse:
                                   gh_mirror_url='bar')
         # content should have been modified, replacing the
         # gh_api_url string by the gh_mirror_url string.
-        assert response.content == 'barbar'.encode()
+        self.assertEqual(response.content, 'barbar'.encode())
 
     def test_status_code(self):
         mock_response = MockResponse(content='foobar',
@@ -86,4 +88,4 @@ class TestResponse:
                                   gh_mirror_url='bar')
 
         # No status code change
-        assert response.status_code == 200
+        self.assertEqual(response.status_code, 200)

--- a/tests/unit/test_reponse.py
+++ b/tests/unit/test_reponse.py
@@ -10,15 +10,6 @@ class MockResponse:
         self.headers = headers
         self.status_code = status_code
 
-    def content(self):
-        return self.content
-
-    def headers(self):
-        return self.headers
-
-    def status_code(self):
-        return self.status_code
-
 
 class TestResponse:
 

--- a/tests/unit/test_reponse.py
+++ b/tests/unit/test_reponse.py
@@ -73,7 +73,7 @@ class TestResponse:
                                   gh_mirror_url='bar')
         # No content from the upstream response should stay the
         # same in the mirror response
-        assert response.content == None
+        assert response.content is None
 
         mock_response = MockResponse(content='foobar',
                                      headers={},

--- a/tests/unit/test_requests.py
+++ b/tests/unit/test_requests.py
@@ -72,13 +72,13 @@ class MockRedis:
             return self.cache[item]
         return None
 
-    def set(self, key, value, ex=None):
+    def set(self, key, value, **_):
         self.cache[key] = value
 
     def _scan_iter(self):
         return iter(self.cache)
 
-    def scan(self, *args):
+    def scan(self, *_args):
         return 0, iter(self.cache)
 
     def dbsize(self):
@@ -88,7 +88,7 @@ class MockRedis:
         return {'used_memory': self.size}
 
 
-def mocked_redis_cache(*args, **kwargs):
+def mocked_redis_cache(*_args, **_kwargs):
     return MockRedis(size=RAND_CACHE_SIZE)
 
 
@@ -100,7 +100,7 @@ class TestRequestsCache(TestCase):
     @mock.patch(
         'ghmirror.data_structures.redis_data_structures.redis.Redis',
         side_effect=mocked_redis_cache)
-    def test_interface_redis(self, mock_cache):
+    def test_interface_redis(self, _mock_cache):
         requests_cache_01 = RequestsCache()
         requests_cache_01['foo'] = MockResponse(content='bar',
                                                 headers={},

--- a/tests/unit/test_requests.py
+++ b/tests/unit/test_requests.py
@@ -15,6 +15,7 @@ RAND_CACHE_SIZE = randint(100, 1000)
 
 class TestStatsCache(TestCase):
 
+    # pylint: disable=W0212
     def test_shared_state(self):
         stats_cache_01 = StatsCache()
         with pytest.raises(AttributeError) as e_info:

--- a/tests/unit/test_requests.py
+++ b/tests/unit/test_requests.py
@@ -143,11 +143,11 @@ class TestParseUrlParameters(TestCase):
 
     def test_url_params_empty(self):
         url_params = None
-        assert _get_elements_per_page(url_params) == None
+        assert _get_elements_per_page(url_params) is None
 
     def test_url_params_no_per_page(self):
         url_params = {}
-        assert _get_elements_per_page(url_params) == None
+        assert _get_elements_per_page(url_params) is None
 
     def test_url_params_per_page(self):
         url_params = {"per_page": 2}
@@ -200,4 +200,4 @@ class TestServeFromCacheCondition(TestCase):
                             status_code=200,
                             text=text)
         header = _should_error_response_be_served_from_cache(resp)
-        assert header == None
+        assert header is None

--- a/tests/unit/test_requests.py
+++ b/tests/unit/test_requests.py
@@ -44,18 +44,6 @@ class MockResponse:
         self.status_code = status_code
         self.text = text
 
-    def content(self):
-        return self.content
-
-    def headers(self):
-        return self.headers
-
-    def status_code(self):
-        return self.status_code
-
-    def text(self):
-        return self.text
-
 
 class MockRedis:
 

--- a/tests/unit/test_requests.py
+++ b/tests/unit/test_requests.py
@@ -13,28 +13,28 @@ from ghmirror.core.mirror_requests import (_get_elements_per_page,
 RAND_CACHE_SIZE = randint(100, 1000)
 
 
-class TestStatsCache:
+class TestStatsCache(TestCase):
 
     def test_shared_state(self):
         stats_cache_01 = StatsCache()
         with pytest.raises(AttributeError) as e_info:
             stats_cache_01.foo
-            assert 'object has no attribute' in e_info.message
-        assert stats_cache_01.counter._value._value == 0
+            self.assertIn('object has no attribute', e_info.message)
+        self.assertEqual(stats_cache_01.counter._value._value, 0)
 
         stats_cache_01.count()
         stats_cache_01.count()
 
-        assert stats_cache_01.counter._value._value == 2
+        self.assertEqual(stats_cache_01.counter._value._value, 2)
 
         stats_cache_02 = StatsCache()
-        assert stats_cache_02.counter._value._value == 2
+        self.assertEqual(stats_cache_02.counter._value._value, 2)
 
         stats_cache_02.count()
         stats_cache_02.count()
 
-        assert stats_cache_01.counter._value._value == 4
-        assert stats_cache_02.counter._value._value == 4
+        self.assertEqual(stats_cache_01.counter._value._value, 4)
+        self.assertEqual(stats_cache_02.counter._value._value, 4)
 
 
 class MockResponse:
@@ -94,13 +94,13 @@ class TestRequestsCache(TestCase):
                                                 headers={},
                                                 status_code=200,
                                                 text='')
-        assert list(requests_cache_01)
-        assert 'foo' in requests_cache_01
+        self.assertTrue(list(requests_cache_01))
+        self.assertIn('foo', requests_cache_01)
 
-        assert requests_cache_01['foo'].content == 'bar'.encode()
-        assert requests_cache_01['foo'].status_code == 200
+        self.assertEqual(requests_cache_01['foo'].content, 'bar'.encode())
+        self.assertEqual(requests_cache_01['foo'].status_code, 200)
 
-        assert requests_cache_01.__sizeof__() == RAND_CACHE_SIZE
+        self.assertEqual(requests_cache_01.__sizeof__(), RAND_CACHE_SIZE)
 
         self.assertRaises(KeyError, lambda: requests_cache_01['bar'])
 
@@ -111,8 +111,8 @@ class TestRequestsCache(TestCase):
                                                 headers={},
                                                 status_code=200,
                                                 text='')
-        assert list(requests_cache_01)
-        assert 'foo' in requests_cache_01
+        self.assertTrue(list(requests_cache_01))
+        self.assertIn('foo', requests_cache_01)
 
     @mock.patch('ghmirror.data_structures.requests_cache.CACHE_TYPE', 'in-memory')
     def test_shared_state(self):
@@ -123,23 +123,23 @@ class TestRequestsCache(TestCase):
                                                 text='')
         requests_cache_02 = RequestsCache()
 
-        assert requests_cache_02['foo'].content == 'bar'.encode()
-        assert requests_cache_02['foo'].status_code == 200
+        self.assertEqual(requests_cache_02['foo'].content, 'bar'.encode())
+        self.assertEqual(requests_cache_02['foo'].status_code, 200)
 
 
 class TestParseUrlParameters(TestCase):
 
     def test_url_params_empty(self):
         url_params = None
-        assert _get_elements_per_page(url_params) is None
+        self.assertIsNone(_get_elements_per_page(url_params))
 
     def test_url_params_no_per_page(self):
         url_params = {}
-        assert _get_elements_per_page(url_params) is None
+        self.assertIsNone(_get_elements_per_page(url_params))
 
     def test_url_params_per_page(self):
         url_params = {"per_page": 2}
-        assert _get_elements_per_page(url_params) == 2
+        self.assertEqual(_get_elements_per_page(url_params), 2)
 
 
 class TestIsRateLimitCondition(TestCase):
@@ -150,7 +150,7 @@ class TestIsRateLimitCondition(TestCase):
                             headers={},
                             status_code=403,
                             text=text)
-        assert _is_rate_limit_error(resp) is True
+        self.assertTrue(_is_rate_limit_error(resp))
 
     def test_is_rate_limit_error_false(self):
         text = "it's fine."
@@ -158,7 +158,7 @@ class TestIsRateLimitCondition(TestCase):
                             headers={},
                             status_code=403,
                             text=text)
-        assert _is_rate_limit_error(resp) is False
+        self.assertFalse(_is_rate_limit_error(resp))
 
 
 class TestServeFromCacheCondition(TestCase):
@@ -170,7 +170,7 @@ class TestServeFromCacheCondition(TestCase):
                             status_code=403,
                             text=text)
         header = _should_error_response_be_served_from_cache(resp)
-        assert header == "RATE_LIMITED"
+        self.assertEqual(header, "RATE_LIMITED")
 
     def test_should_serve_from_cache_api_error(self):
         text = "it's fine."
@@ -179,7 +179,7 @@ class TestServeFromCacheCondition(TestCase):
                             status_code=500,
                             text=text)
         header = _should_error_response_be_served_from_cache(resp)
-        assert header == "API_ERROR"
+        self.assertEqual(header, "API_ERROR")
 
     def test_should_serve_from_cache_ok(self):
         text = "it's fine."
@@ -188,4 +188,4 @@ class TestServeFromCacheCondition(TestCase):
                             status_code=200,
                             text=text)
         header = _should_error_response_be_served_from_cache(resp)
-        assert header is None
+        self.assertIsNone(header)


### PR DESCRIPTION
This series of commits improves the pylint score for the tests as suggested in #58
The remainder of the pylint warnings are all about doc strings (C___)

There are multiple ways to resolve certain warnings. I solved the unused argument warnings with _ prefix in cases where the arg was not used but required by the protocol. I'm happy to discuss other ways (locally disabling the linter check or assigning all unused vars like _ = (unused_1, unused_2, ..)
