### PR TITLE
Use non-deprecated topology keys

### DIFF
--- a/openshift/github-mirror.yaml
+++ b/openshift/github-mirror.yaml
@@ -53,7 +53,7 @@ objects:
                       operator: In
                       values:
                       - github-mirror
-                  topologyKey: failure-domain.beta.kubernetes.io/zone
+                  topologyKey: topology.kubernetes.io/zone
                 weight: 100
         containers:
         - image: ${IMAGE}:${IMAGE_TAG}


### PR DESCRIPTION
failure-domain.beta.kubernetes.io/zone is deprecated from k8s 1.17

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>