### PR TITLE
Add more weight to zone antiaffinity

### DIFF
--- a/openshift/github-mirror.yaml
+++ b/openshift/github-mirror.yaml
@@ -45,7 +45,7 @@ objects:
                       values:
                       - github-mirror
                   topologyKey: kubernetes.io/hostname
-                weight: 100
+                weight: 90
               - podAffinityTerm:
                   labelSelector:
                     matchExpressions:


### PR DESCRIPTION
We want that the scheduler tries harder to spread in different AZs,
which will lead to different hosts anyway in the happiest case.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>