### PR TITLE
apiVersion update

### DIFF
--- a/openshift/github-mirror.yaml
+++ b/openshift/github-mirror.yaml
@@ -4,7 +4,7 @@ kind: Template
 metadata:
   name: github-mirror
 objects:
-- apiVersion: policy/v1beta1
+- apiVersion: policy/v1
   kind: PodDisruptionBudget
   metadata:
     name: github-mirror


### PR DESCRIPTION
fix the following reconcile error : 
CURRENT: {"apiVersion": "policy/v1",      "kind": "PodDisruptionBudget", "metadata": {"annotations": {}, "name": "github-mirror"}, "spec": {"minAvailable": 1, "selector": {"matchLabels": {"app": "github-mirror"}}}}


DESIRED: {"apiVersion": "policy/v1beta1", "kind": "PodDisruptionBudget", "metadata": {"annotations": {}, "name": "github-mirror"}, "spec": {"minAvailable": 1, "selector": {"matchLabels": {"app": "github-mirror"}}}}
