### PR TITLE
Build image as user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,21 @@
 FROM        registry.access.redhat.com/ubi8/ubi-minimal
 
-RUN         microdnf install python3.9 make && microdnf clean all
+RUN         microdnf install python3.9 make shadow-utils && microdnf clean all
 RUN         python3 -m pip install --no-cache-dir --upgrade pip setuptools
 
-USER        root
+ARG         CONTAINER_UID=1000
+RUN         adduser --uid ${CONTAINER_UID} --user-group ghmirror
+RUN         mkdir /ghmirror && chown ghmirror:ghmirror /ghmirror
+
+USER        ghmirror
+ENV         PATH=${PATH}:/home/ghmirror/.local/bin
 
 WORKDIR     /ghmirror
 
-COPY        . ./
+COPY        --chown=ghmirror:ghmirror . ./
 
-RUN         pip install .
-RUN         pip install gunicorn
+RUN         pip install --no-cache-dir --user .
+RUN         pip install --no-cache-dir --user gunicorn
 
 ENTRYPOINT  ["gunicorn", "ghmirror.app:APP"]
 CMD         ["--workers", "1", "--threads",  "8", "--bind", "0.0.0.0:8080"]


### PR DESCRIPTION
We need that in order to be able to install dependencies before running acceptance tests.

Follows #83 and #84

https://issues.redhat.com/browse/APPSRE-6578

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>