### PR TITLE
Revert "Unset CPU limits"

### DIFF
--- a/openshift/github-mirror-acceptance.yaml
+++ b/openshift/github-mirror-acceptance.yaml
@@ -13,8 +13,6 @@ objects:
 - apiVersion: batch/v1
   kind: Job
   metadata:
-    annotations:
-      ignore-check.kube-linter.io/unset-cpu-requirements: "no cpu limits"
     name: github-mirror-acceptance-${IMAGE_TAG}
   spec:
     backoffLimit: 5
@@ -44,6 +42,7 @@ objects:
                 cpu: ${CPU_REQUESTS}
               limits:
                 memory: ${MEMORY_LIMIT}
+                cpu: ${CPU_LIMIT}
 parameters:
 - name: IMAGE
   value: quay.io/app-sre/github-mirror
@@ -65,4 +64,6 @@ parameters:
 - name: MEMORY_LIMIT
   value: 128Mi
 - name: CPU_REQUESTS
-  value: 100m
+  value: 300m
+- name: CPU_LIMIT
+  value: 300m

--- a/openshift/github-mirror.yaml
+++ b/openshift/github-mirror.yaml
@@ -22,8 +22,6 @@ objects:
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
-    annotations:
-      ignore-check.kube-linter.io/unset-cpu-requirements: "no cpu limits"
     labels:
       app: github-mirror
     name: github-mirror
@@ -117,6 +115,7 @@ objects:
               cpu: ${CPU_REQUESTS}
             limits:
               memory: ${MEMORY_LIMIT}
+              cpu: ${CPU_LIMIT}
 - apiVersion: v1
   kind: Service
   metadata:
@@ -150,7 +149,9 @@ parameters:
 # we need more, we should probably increase the number
 # of replicas instead of touching it here.
 - name: CPU_REQUESTS
-  value: 200m
+  value: 500m
+- name: CPU_LIMIT
+  value: 1000m
 # These values are meant to be overridden by the
 # saas-herder parametrization
 - name: GITHUB_USERS


### PR DESCRIPTION
This is making GH mirror to go in offline mode a lot of the time. We still don't know why, but it aligns perfectly in the dashboards.

This reverts commit f512bc6677223cc26798e9de82ca53b7f63cd5f0.