### PR TITLE
Make GithubStatus thread safe singleton

### DIFF
--- a/ghmirror/data_structures/monostate.py
+++ b/ghmirror/data_structures/monostate.py
@@ -79,11 +79,13 @@ class GithubStatus:
     """
 
     _instance = None
+    _lock = threading.Lock()
 
     @classmethod
     def __new__(cls, *args, **kwargs):  # pylint: disable=unused-argument
-        if cls._instance is None:
-            cls._instance = _GithubStatus()
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = _GithubStatus()
         return cls._instance
 
 


### PR DESCRIPTION
`GithubStatus` singleton is not thread safe, can be multiple instance created concurrently, add a thread lock to guard it.