### PR TITLE
Allow to increase sleep time in github status check

### DIFF
--- a/ghmirror/data_structures/monostate.py
+++ b/ghmirror/data_structures/monostate.py
@@ -16,6 +16,7 @@
 Caching data structures.
 """
 
+import os
 import threading
 import time
 import logging
@@ -46,7 +47,7 @@ LOG = logging.getLogger(__name__)
 
 class _GithubStatus:
 
-    SLEEP_TIME = 1
+    SLEEP_TIME = int(os.environ.get("GITHUB_STATUS_SLEEP_TIME", 1))
 
     def __init__(self):
         self.online = True

--- a/openshift/github-mirror.yaml
+++ b/openshift/github-mirror.yaml
@@ -92,6 +92,8 @@ objects:
                     name: ${EC_SECRET_NAME}
             - name: REDIS_SSL
               value: ${REDIS_SSL}
+            - name: GITHUB_STATUS_SLEEP_TIME
+              value: "${GITHUB_STATUS_SLEEP_TIME}"
           ports:
           - name: github-mirror
             containerPort: 8080
@@ -173,3 +175,5 @@ parameters:
   value: "github-mirror"
   deplayName: github-mirror service account
   description: name of the service account to use when deploying the pod
+- name: GITHUB_STATUS_SLEEP_TIME
+  value: '1'


### PR DESCRIPTION
We are currently hammering the status endpoint and we're getting rate limited. Every time we get rate limited, github mirror thinks it has to go offline, so this tries to mitigate it.

We cannot go crazy with this approach as the same sleep time is used to enter and to exit from the offline mode.

Related to APPSRE-8243