### PR TITLE
New GitHub status check API

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,9 @@ the rate limit will be preserved when possible.
 There's a built-in mechanism to detect when the Github API is offline.
 
 To do so, we have a separate thread that keeps checking the url
-`https://api.github.com/status` every second. When we don't get a success
-response, we consider the Github API offline.
+`https://www.githubstatus.com/api/v2/components.json` every second.
+When we don't get a success response, or `API` component is `major_outage`,
+we consider the Github API offline.
 
 When that happens, all the requests are served from the cache until we detect
 that the Github API is back online.

--- a/ghmirror/core/constants.py
+++ b/ghmirror/core/constants.py
@@ -17,6 +17,7 @@ System constants.
 """
 
 GH_API = 'https://api.github.com'
+GH_STATUS_API = 'https://www.githubstatus.com/api/v2/components.json'
 REQUESTS_TIMEOUT = 10
 STATUS_TIMEOUT = 2
 PER_PAGE_ELEMENTS = 30

--- a/ghmirror/data_structures/monostate.py
+++ b/ghmirror/data_structures/monostate.py
@@ -47,9 +47,10 @@ LOG = logging.getLogger(__name__)
 
 class _GithubStatus:
 
-    def __init__(self, sleep_time):
+    def __init__(self, sleep_time, session):
         self.sleep_time = sleep_time
         self.online = True
+        self.session = session
         self._start_check()
 
     def _start_check(self):
@@ -67,7 +68,7 @@ class _GithubStatus:
         Class method to create a new instance of _GithubStatus.
         """
         sleep_time = int(os.environ.get("GITHUB_STATUS_SLEEP_TIME", 1))
-        return cls(sleep_time)
+        return cls(sleep_time, requests.Session())
 
     def check(self):
         """
@@ -77,8 +78,8 @@ class _GithubStatus:
         """
         while True:
             try:
-                response = requests.get(f'{GH_API}/status',
-                                        timeout=STATUS_TIMEOUT)
+                response = self.session.get(f'{GH_API}/status',
+                                            timeout=STATUS_TIMEOUT)
                 response.raise_for_status()
                 self.online = True
             except (requests.exceptions.ConnectionError,

--- a/ghmirror/data_structures/monostate.py
+++ b/ghmirror/data_structures/monostate.py
@@ -94,6 +94,9 @@ class _GithubStatus:
                                             timeout=STATUS_TIMEOUT)
                 response.raise_for_status()
                 self.online = self._is_github_online(response)
+                if not self.online:
+                    LOG.warning('Github API is offline, response: %s',
+                                response.text)
             except (requests.exceptions.ConnectionError,
                     requests.exceptions.Timeout,
                     requests.exceptions.HTTPError) as error:

--- a/ghmirror/data_structures/monostate.py
+++ b/ghmirror/data_structures/monostate.py
@@ -32,7 +32,7 @@ from prometheus_client import Gauge
 from prometheus_client import Histogram
 from prometheus_client import ProcessCollector
 
-from ghmirror.core.constants import GH_API
+from ghmirror.core.constants import GH_STATUS_API
 from ghmirror.core.constants import STATUS_TIMEOUT
 
 
@@ -62,6 +62,18 @@ class _GithubStatus:
         thread = threading.Thread(target=self.check, daemon=True)
         thread.start()
 
+    @staticmethod
+    def _is_github_online(response):
+        """
+        Check if the Github API is online based on the response.
+        If API component status is major_outage, then it's offline.
+        If API component status is one of operational,
+        degraded_performance, or partial_outage, then it's online.
+        """
+        components = response.json()['components']
+        return any(c['name'] == 'API' and c['status'] != 'major_outage'
+                   for c in components)
+
     @classmethod
     def create(cls):
         """
@@ -78,10 +90,10 @@ class _GithubStatus:
         """
         while True:
             try:
-                response = self.session.get(f'{GH_API}/status',
+                response = self.session.get(GH_STATUS_API,
                                             timeout=STATUS_TIMEOUT)
                 response.raise_for_status()
-                self.online = True
+                self.online = self._is_github_online(response)
             except (requests.exceptions.ConnectionError,
                     requests.exceptions.Timeout,
                     requests.exceptions.HTTPError) as error:

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -1,4 +1,3 @@
-import hashlib
 from unittest import mock
 
 import pytest
@@ -70,14 +69,21 @@ def mocked_requests_monitor_good(*_args, **_kwargs):
 def mocked_requests_monitor_bad(*_args, **_kwargs):
     return MockResponse('', {}, 403)
 
+
+def setup_mocked_requests_session_get(mocked_session, side_effect):
+    mocked_session.return_value.get.side_effect = side_effect
+
+
 def mocked_requests_rate_limited(*_args, **_kwargs):
     return MockResponse('API rate limit exceeded', {}, 403)
+
 
 def mocked_requests_api_corner_case(*_args, **kwargs):
     if 'If-None-Match' in kwargs['headers']:
         return MockResponse('', {}, 304, json_content=[{'a': 'b'}, {'c', 'd'}])
 
     return MockResponse('', {'ETag': 'foo'}, 200, json_content=[{'a': 'b'}, {'c', 'd'}])
+
 
 @pytest.fixture(name="client")
 def fixture_client():
@@ -95,7 +101,9 @@ def test_healthz(client):
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
             side_effect=mocked_requests_get_etag)
-def test_mirror_etag(_mock_get, client):
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
+def test_mirror_etag(mock_monitor_session, _mock_get, client):
+    setup_mocked_requests_session_get(mock_monitor_session, mocked_requests_monitor_good)
     # Initially the stats are zeroed
     response = client.get('/metrics')
     assert response.status_code == 200
@@ -133,7 +141,9 @@ def test_mirror_etag(_mock_get, client):
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
             side_effect=mocked_requests_get_last_modified)
-def test_mirror_last_modified(_mock_get, client):
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
+def test_mirror_last_modified(mock_monitor_session, _mock_get, client):
+    setup_mocked_requests_session_get(mock_monitor_session, mocked_requests_monitor_good)
     # Initially the stats are zeroed
     response = client.get('/metrics')
     assert response.status_code == 200
@@ -170,7 +180,9 @@ def test_mirror_last_modified(_mock_get, client):
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
             side_effect=mocked_requests_get_last_modified)
-def test_mirror_upstream_call(mocked_request, client):
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
+def test_mirror_upstream_call(mock_monitor_session, mocked_request, client):
+    setup_mocked_requests_session_get(mock_monitor_session, mocked_requests_monitor_good)
     client.get('/user/repos?page=2',
                headers={'Authorization': 'foo'})
     expected_url = 'https://api.github.com/user/repos?page=2'
@@ -183,7 +195,9 @@ def test_mirror_upstream_call(mocked_request, client):
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
             side_effect=mocked_requests_get_last_modified)
-def test_mirror_non_get(mocked_request, client):
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
+def test_mirror_non_get(mock_monitor_session, mocked_request, client):
+    setup_mocked_requests_session_get(mock_monitor_session, mocked_requests_monitor_good)
     client.patch('/repos/foo/bar', data=b'foo')
     expected_url = 'https://api.github.com/repos/foo/bar'
     mocked_request.assert_called_with(method='PATCH', data=b'foo', headers={},
@@ -196,7 +210,9 @@ def test_mirror_non_get(mocked_request, client):
 @mock.patch('ghmirror.decorators.checks.conditional_request',
             side_effect=mocked_requests_get_user_orgs_auth)
 @mock.patch('ghmirror.core.mirror_requests.requests.request')
-def test_mirror_authorized_user(mocked_request, mocked_cond_request, client):
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
+def test_mirror_authorized_user(mock_monitor_session, mocked_request, mocked_cond_request, client):
+    setup_mocked_requests_session_get(mock_monitor_session, mocked_requests_monitor_good)
     client.get('/repos/app-sre/github-mirror',
                headers={'Authorization': 'foo'})
     mocked_cond_request.assert_called_with(auth='foo', method='GET',
@@ -213,8 +229,12 @@ def test_mirror_authorized_user(mocked_request, mocked_cond_request, client):
 @mock.patch('ghmirror.decorators.checks.conditional_request',
             side_effect=mocked_requests_get_user_orgs_auth)
 @mock.patch('ghmirror.core.mirror_requests.requests.request')
-def test_mirror_authorized_user_cached(mocked_request, mocked_cond_request,
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
+def test_mirror_authorized_user_cached(mock_monitor_session,
+                                       mocked_request,
+                                       mocked_cond_request,
                                        client):
+    setup_mocked_requests_session_get(mock_monitor_session, mocked_requests_monitor_good)
     users_cache = UsersCache()
     auth = 'foo'
     users_cache.add(auth)
@@ -233,14 +253,18 @@ def test_mirror_authorized_user_cached(mocked_request, mocked_cond_request,
 @mock.patch('ghmirror.decorators.checks.AUTHORIZED_USERS', 'app-sre-bot')
 @mock.patch('ghmirror.decorators.checks.conditional_request',
             side_effect=mocked_requests_get_user_orgs_unauth)
-def test_mirror_user_forbidden(_mocked_cond_request, client):
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
+def test_mirror_user_forbidden(mock_monitor_session, _mocked_cond_request, client):
+    setup_mocked_requests_session_get(mock_monitor_session, mocked_requests_monitor_good)
     response = client.get('/repos/app-sre/github-mirror',
                           headers={'Authorization': 'foo'})
     assert response.status_code == 403
 
 
 @mock.patch('ghmirror.decorators.checks.AUTHORIZED_USERS', 'app-sre-bot')
-def test_mirror_no_auth(client):
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
+def test_mirror_no_auth(mock_monitor_session, client):
+    setup_mocked_requests_session_get(mock_monitor_session, mocked_requests_monitor_good)
     response = client.get('/repos/app-sre/github-mirror',
                           headers={})
     assert response.status_code == 401
@@ -249,7 +273,9 @@ def test_mirror_no_auth(client):
 @mock.patch('ghmirror.decorators.checks.AUTHORIZED_USERS', 'app-sre-bot')
 @mock.patch('ghmirror.decorators.checks.conditional_request',
             side_effect=mocked_requests_get_error)
-def test_mirror_auth_error(_mocked_cond_request, client):
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
+def test_mirror_auth_error(mock_monitor_session, _mocked_cond_request, client):
+    setup_mocked_requests_session_get(mock_monitor_session, mocked_requests_monitor_good)
     response = client.get('/repos/app-sre/github-mirror',
                           headers={'Authorization': 'foo'})
     assert response.status_code == 500
@@ -257,9 +283,9 @@ def test_mirror_auth_error(_mocked_cond_request, client):
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
             side_effect=mocked_requests_get_etag)
-@mock.patch('ghmirror.data_structures.monostate.requests.get',
-            side_effect=mocked_requests_monitor_good)
-def test_offline_mode(mock_monitor_get, _mock_request, client):
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
+def test_offline_mode(mock_monitor_session, _mock_request, client):
+    setup_mocked_requests_session_get(mock_monitor_session, mocked_requests_monitor_good)
     # Let's wait the mirror consider itself online
     assert wait_for(lambda: GithubStatus().online, timeout=5)
 
@@ -273,7 +299,7 @@ def test_offline_mode(mock_monitor_get, _mock_request, client):
             'method="GET",status="200",user="None"} 1.0') in str(response.data)
 
     # Now make the mirror go offline for upstream timeout
-    mock_monitor_get.side_effect = requests.exceptions.Timeout
+    setup_mocked_requests_session_get(mock_monitor_session, requests.exceptions.Timeout)
 
     # Let's wait the mirror to consider itself offline
     assert wait_for(lambda: not GithubStatus().online, timeout=5)
@@ -309,9 +335,9 @@ def test_offline_mode(mock_monitor_get, _mock_request, client):
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
             side_effect=mocked_requests_get_etag)
-@mock.patch('ghmirror.data_structures.monostate.requests.get',
-            side_effect=mocked_requests_monitor_good)
-def test_offline_mode_upstream_error(mock_monitor_get, _mock_request, client):
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
+def test_offline_mode_upstream_error(mock_monitor_session, _mock_request, client):
+    setup_mocked_requests_session_get(mock_monitor_session, mocked_requests_monitor_good)
     # Let's wait the mirror consider itself online
     assert wait_for(lambda: GithubStatus().online, timeout=5)
 
@@ -326,7 +352,7 @@ def test_offline_mode_upstream_error(mock_monitor_get, _mock_request, client):
             'method="GET",status="200",user="None"} 1.0') in str(response.data)
 
     # Now make the mirror go offline for upstream error
-    mock_monitor_get.side_effect = mocked_requests_monitor_bad
+    setup_mocked_requests_session_get(mock_monitor_session, mocked_requests_get_error)
 
     # Let's wait the mirror to consider itself offline
     assert wait_for(lambda: not GithubStatus().online, timeout=5)
@@ -344,9 +370,9 @@ def test_offline_mode_upstream_error(mock_monitor_get, _mock_request, client):
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
             side_effect=mocked_requests_rate_limited)
-@mock.patch('ghmirror.data_structures.monostate.requests.get',
-            side_effect=mocked_requests_monitor_good)
-def test_rate_limited(_mock_monitor_get, mock_request, client):
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
+def test_rate_limited(_mock_monitor_session, mock_request, client):
+    setup_mocked_requests_session_get(_mock_monitor_session, mocked_requests_monitor_good)
     # First request will get a 403/rate-limited. Because it's not cached
     # yet, we receive the same 403
     response = client.get('/repos/app-sre/github-mirror')
@@ -381,7 +407,9 @@ def test_rate_limited(_mock_monitor_get, mock_request, client):
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
             side_effect=mocked_requests_api_corner_case)
-def test_pagination_corner_case_custom_page_elements(_mock_get, client):
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
+def test_pagination_corner_case_custom_page_elements(mock_monitor_session, _mock_get, client):
+    setup_mocked_requests_session_get(mock_monitor_session, mocked_requests_monitor_good)
     # Initially the stats are zeroed
     response = client.get('/metrics')
     assert response.status_code == 200
@@ -422,7 +450,9 @@ def test_pagination_corner_case_custom_page_elements(_mock_get, client):
 @mock.patch('ghmirror.core.mirror_requests.PER_PAGE_ELEMENTS', 2)
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
             side_effect=mocked_requests_api_corner_case)
-def test_pagination_corner_case(_mock_get, client):
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
+def test_pagination_corner_case(mock_monitor_session, _mock_get, client):
+    setup_mocked_requests_session_get(mock_monitor_session, mocked_requests_monitor_good)
     # Initially the stats are zeroed
     response = client.get('/metrics')
     assert response.status_code == 200
@@ -462,7 +492,9 @@ def test_pagination_corner_case(_mock_get, client):
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
             side_effect=requests.exceptions.Timeout)
-def test_mirror_request_timeout(_mock_get, client):
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
+def test_mirror_request_timeout(mock_monitor_session, _mock_get, client):
+    setup_mocked_requests_session_get(mock_monitor_session, mocked_requests_monitor_good)
     # Initially the stats are zeroed
     response = client.get('/metrics')
     assert response.status_code == 200
@@ -479,7 +511,9 @@ def test_mirror_request_timeout(_mock_get, client):
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
             side_effect=mocked_requests_get_etag)
-def test_mirror_request_timeout_hit(mock_get, client):
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
+def test_mirror_request_timeout_hit(mock_monitor_session, mock_get, client):
+    setup_mocked_requests_session_get(mock_monitor_session, mocked_requests_monitor_good)
     # Initially the stats are zeroed
     response = client.get('/metrics')
     assert response.status_code == 200
@@ -518,7 +552,9 @@ def test_mirror_request_timeout_hit(mock_get, client):
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
             side_effect=mocked_requests_get_etag)
-def test_mirror_request_5xx(mock_get, client):
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
+def test_mirror_request_5xx(mock_monitor_session, mock_get, client):
+    setup_mocked_requests_session_get(mock_monitor_session, mocked_requests_monitor_good)
     # Initially the stats are zeroed
     response = client.get('/metrics')
     assert response.status_code == 200
@@ -558,7 +594,9 @@ def test_mirror_request_5xx(mock_get, client):
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
             side_effect=mocked_requests_get_etag)
-def test_mirror_request_5xx_miss(mock_get, client):
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
+def test_mirror_request_5xx_miss(mock_monitor_session, mock_get, client):
+    setup_mocked_requests_session_get(mock_monitor_session, mocked_requests_monitor_good)
     # Initially the stats are zeroed
     response = client.get('/metrics')
     assert response.status_code == 200
@@ -597,7 +635,9 @@ def test_mirror_request_5xx_miss(mock_get, client):
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
             side_effect=mocked_requests_get_etag)
-def test_mirror_request_connection_error_hit(mock_get, client):
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
+def test_mirror_request_connection_error_hit(mock_monitor_session, mock_get, client):
+    setup_mocked_requests_session_get(mock_monitor_session, mocked_requests_monitor_good)
     # Initially the stats are zeroed
     response = client.get('/metrics')
     assert response.status_code == 200
@@ -636,8 +676,9 @@ def test_mirror_request_connection_error_hit(mock_get, client):
 
 @mock.patch('ghmirror.core.mirror_requests.requests.request',
             side_effect=mocked_requests_get_etag)
-def test_mirror_request_connection_error_miss(mock_get, client):
-
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
+def test_mirror_request_connection_error_miss(mock_monitor_session, mock_get, client):
+    setup_mocked_requests_session_get(mock_monitor_session, mocked_requests_monitor_good)
     mock_get.side_effect = requests.exceptions.ConnectionError
     response = client.get('/repos/app-sre/github-mirror',
                           follow_redirects=True)

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -63,7 +63,14 @@ def mocked_requests_get_error(*_args, **_kwargs):
 
 
 def mocked_requests_monitor_good(*_args, **_kwargs):
-    return MockResponse('', {}, 200)
+    return MockResponse('',
+                        {},
+                        200,
+                        json_content={
+                            'components': [
+                                {'name': 'API', 'status': 'operational'}
+                            ]
+                        })
 
 
 def mocked_requests_monitor_bad(*_args, **_kwargs):

--- a/tests/unit/test_github_status.py
+++ b/tests/unit/test_github_status.py
@@ -20,35 +20,37 @@ def test_create_github_status_singleton(_mock_thread):
                              ('3', 3),
                              (1, 1),
                          ])
+@mock.patch('ghmirror.data_structures.monostate.requests.Session')
 @mock.patch('ghmirror.data_structures.monostate.os.environ')
 @mock.patch('ghmirror.data_structures.monostate.threading.Thread')
-def test_create_github_status(mock_thread, mock_environ, env_sleep_time, expected_sleep_time):
+def test_create_github_status(mock_thread, mock_environ, mock_session, env_sleep_time, expected_sleep_time):
     mock_environ.get.return_value = env_sleep_time
 
     github_status = _GithubStatus.create()
 
     assert github_status.online is True
     assert github_status.sleep_time == expected_sleep_time
+    assert github_status.session is mock_session.return_value
     mock_thread.assert_called_once_with(target=github_status.check, daemon=True)
-    mock_thread.return_value.start.assert_called_once()
+    mock_thread.return_value.start.assert_called_once_with()
     mock_environ.get.assert_called_once_with('GITHUB_STATUS_SLEEP_TIME', 1)
+    mock_session.assert_called_once_with()
 
 
-
-@mock.patch('ghmirror.data_structures.monostate.requests.get')
 @mock.patch('ghmirror.data_structures.monostate.time.sleep', side_effect=InterruptedError)
 @mock.patch('ghmirror.data_structures.monostate.threading.Thread')
-def test_github_status_check_success(_mock_thread, mock_sleep, mock_requests_get):
+def test_github_status_check_success(_mock_thread, mock_sleep):
     mocked_response = mock.create_autospec(requests.Response)
-    mock_requests_get.return_value = mocked_response
+    session = mock.create_autospec(requests.Session)
+    session.get.return_value = mocked_response
     sleep_time = 1
-    github_status = _GithubStatus(sleep_time=sleep_time)
+    github_status = _GithubStatus(sleep_time=sleep_time, session=session)
 
     with pytest.raises(InterruptedError):
         github_status.check()
 
     assert github_status.online is True
-    mock_requests_get.assert_called_once_with('https://api.github.com/status', timeout=2)
+    session.get.assert_called_once_with('https://api.github.com/status', timeout=2)
     mocked_response.raise_for_status.assert_called_once_with()
     mock_sleep.assert_called_once_with(sleep_time)
 
@@ -60,21 +62,21 @@ def test_github_status_check_success(_mock_thread, mock_sleep, mock_requests_get
                              (requests.exceptions.Timeout('Timeout')),
                          ])
 @mock.patch('ghmirror.data_structures.monostate.LOG')
-@mock.patch('ghmirror.data_structures.monostate.requests.get')
 @mock.patch('ghmirror.data_structures.monostate.time.sleep', side_effect=InterruptedError)
 @mock.patch('ghmirror.data_structures.monostate.threading.Thread')
-def test_github_status_check_fail(_mock_thread, mock_sleep, mock_requests_get, mock_log, error):
+def test_github_status_check_fail(_mock_thread, mock_sleep, mock_log, error):
     mocked_response = mock.create_autospec(requests.Response)
-    mock_requests_get.return_value = mocked_response
+    session = mock.create_autospec(requests.Session)
+    session.get.return_value = mocked_response
     mocked_response.raise_for_status.side_effect = error
     sleep_time = 1
-    github_status = _GithubStatus(sleep_time=sleep_time)
+    github_status = _GithubStatus(sleep_time=sleep_time, session=session)
 
     with pytest.raises(InterruptedError):
         github_status.check()
 
     assert github_status.online is False
     mock_log.warning.assert_called_once_with('Github API is offline, reason: %s', error)
-    mock_requests_get.assert_called_once_with('https://api.github.com/status', timeout=2)
+    session.get.assert_called_once_with('https://api.github.com/status', timeout=2)
     mocked_response.raise_for_status.assert_called_once_with()
     mock_sleep.assert_called_once_with(sleep_time)


### PR DESCRIPTION
https://api.github.com/status endpoint is rate limited, switch to https://www.githubstatus.com/api/v2/components.json.

When `API` component status is `major_outage`, we consider Github API is offline.

Also switch to `requests.Session` for better performance and easy test.