### PR TITLE
Increase STATUS_TIMEOUT to 10s

### DIFF
--- a/ghmirror/core/constants.py
+++ b/ghmirror/core/constants.py
@@ -19,5 +19,6 @@ System constants.
 GH_API = 'https://api.github.com'
 GH_STATUS_API = 'https://www.githubstatus.com/api/v2/components.json'
 REQUESTS_TIMEOUT = 10
+STATUS_SLEEP_TIME = 1
 STATUS_TIMEOUT = 10
 PER_PAGE_ELEMENTS = 30

--- a/ghmirror/core/constants.py
+++ b/ghmirror/core/constants.py
@@ -19,5 +19,5 @@ System constants.
 GH_API = 'https://api.github.com'
 GH_STATUS_API = 'https://www.githubstatus.com/api/v2/components.json'
 REQUESTS_TIMEOUT = 10
-STATUS_TIMEOUT = 2
+STATUS_TIMEOUT = 10
 PER_PAGE_ELEMENTS = 30

--- a/ghmirror/data_structures/monostate.py
+++ b/ghmirror/data_structures/monostate.py
@@ -32,8 +32,11 @@ from prometheus_client import Gauge
 from prometheus_client import Histogram
 from prometheus_client import ProcessCollector
 
-from ghmirror.core.constants import GH_STATUS_API
-from ghmirror.core.constants import STATUS_TIMEOUT
+from ghmirror.core.constants import (
+    GH_STATUS_API,
+    STATUS_SLEEP_TIME,
+    STATUS_TIMEOUT,
+)
 
 
 __all__ = ['GithubStatus', 'InMemoryCache', 'StatsCache', 'UsersCache']
@@ -47,10 +50,11 @@ LOG = logging.getLogger(__name__)
 
 class _GithubStatus:
 
-    def __init__(self, sleep_time, session):
+    def __init__(self, sleep_time, timeout, session):
         self.sleep_time = sleep_time
-        self.online = True
+        self.timeout = timeout
         self.session = session
+        self.online = True
         self._start_check()
 
     def _start_check(self):
@@ -80,8 +84,13 @@ class _GithubStatus:
         """
         Class method to create a new instance of _GithubStatus.
         """
-        sleep_time = int(os.environ.get("GITHUB_STATUS_SLEEP_TIME", 1))
-        return cls(sleep_time, requests.Session())
+        sleep_time = int(os.environ.get("GITHUB_STATUS_SLEEP_TIME",
+                                        STATUS_SLEEP_TIME))
+        timeout = int(os.environ.get("GITHUB_STATUS_TIMEOUT",
+                                     STATUS_TIMEOUT))
+        return cls(sleep_time=sleep_time,
+                   timeout=timeout,
+                   session=requests.Session())
 
     def check(self):
         """

--- a/openshift/github-mirror.yaml
+++ b/openshift/github-mirror.yaml
@@ -94,6 +94,8 @@ objects:
               value: ${REDIS_SSL}
             - name: GITHUB_STATUS_SLEEP_TIME
               value: "${GITHUB_STATUS_SLEEP_TIME}"
+            - name: GITHUB_STATUS_TIMEOUT
+              value: "${GITHUB_STATUS_TIMEOUT}"
           ports:
           - name: github-mirror
             containerPort: 8080
@@ -177,3 +179,5 @@ parameters:
   description: name of the service account to use when deploying the pod
 - name: GITHUB_STATUS_SLEEP_TIME
   value: '1'
+- name: GITHUB_STATUS_TIMEOUT
+  value: '10'

--- a/tests/unit/test_github_status.py
+++ b/tests/unit/test_github_status.py
@@ -6,6 +6,8 @@ import requests
 from ghmirror.data_structures.monostate import GithubStatus, _GithubStatus
 
 EXPECTED_TIMEOUT = 10
+EXPECTED_SLEEP_TIME = 1
+
 
 @mock.patch('ghmirror.data_structures.monostate.threading.Thread')
 def test_create_github_status_singleton(_mock_thread):
@@ -16,25 +18,29 @@ def test_create_github_status_singleton(_mock_thread):
     assert github_status is github_status2
 
 
-@pytest.mark.parametrize('env_sleep_time,expected_sleep_time',
+@pytest.mark.parametrize('env,expected_sleep_time,expected_timeout',
                          [
-                             ('3', 3),
-                             (1, 1),
+                             ({}, 1, 10),
+                             ({'GITHUB_STATUS_SLEEP_TIME': '3'}, 3, 10),
+                             ({'GITHUB_STATUS_TIMEOUT': '2'}, 1, 2),
                          ])
 @mock.patch('ghmirror.data_structures.monostate.requests.Session')
-@mock.patch('ghmirror.data_structures.monostate.os.environ')
 @mock.patch('ghmirror.data_structures.monostate.threading.Thread')
-def test_create_github_status(mock_thread, mock_environ, mock_session, env_sleep_time, expected_sleep_time):
-    mock_environ.get.return_value = env_sleep_time
-
-    github_status = _GithubStatus.create()
+def test_create_github_status_with_sleep_time(mock_thread,
+                                              mock_session,
+                                              env,
+                                              expected_sleep_time,
+                                              expected_timeout):
+    with mock.patch.dict('ghmirror.data_structures.monostate.os.environ',
+                         env):
+        github_status = _GithubStatus.create()
 
     assert github_status.online is True
     assert github_status.sleep_time == expected_sleep_time
+    assert github_status.timeout == expected_timeout
     assert github_status.session is mock_session.return_value
     mock_thread.assert_called_once_with(target=github_status.check, daemon=True)
     mock_thread.return_value.start.assert_called_once_with()
-    mock_environ.get.assert_called_once_with('GITHUB_STATUS_SLEEP_TIME', 1)
     mock_session.assert_called_once_with()
 
 
@@ -94,8 +100,9 @@ def test_github_status_check_success(_mock_thread, mock_sleep, status):
     mocked_response.json.return_value = build_github_status_response_builder(status)
     session = mock.create_autospec(requests.Session)
     session.get.return_value = mocked_response
-    sleep_time = 1
-    github_status = _GithubStatus(sleep_time=sleep_time, session=session)
+    github_status = _GithubStatus(sleep_time=EXPECTED_SLEEP_TIME,
+                                  timeout=EXPECTED_TIMEOUT,
+                                  session=session)
 
     with pytest.raises(InterruptedError):
         github_status.check()
@@ -104,7 +111,7 @@ def test_github_status_check_success(_mock_thread, mock_sleep, status):
     session.get.assert_called_once_with('https://www.githubstatus.com/api/v2/components.json',
                                         timeout=EXPECTED_TIMEOUT)
     mocked_response.raise_for_status.assert_called_once_with()
-    mock_sleep.assert_called_once_with(sleep_time)
+    mock_sleep.assert_called_once_with(EXPECTED_SLEEP_TIME)
 
 
 @mock.patch('ghmirror.data_structures.monostate.LOG')
@@ -115,8 +122,9 @@ def test_github_status_check_outage(_mock_thread, mock_sleep, mock_log):
     mocked_response.json.return_value = build_github_status_response_builder('major_outage')
     session = mock.create_autospec(requests.Session)
     session.get.return_value = mocked_response
-    sleep_time = 1
-    github_status = _GithubStatus(sleep_time=sleep_time, session=session)
+    github_status = _GithubStatus(sleep_time=EXPECTED_SLEEP_TIME,
+                                  timeout=EXPECTED_TIMEOUT,
+                                  session=session)
 
     with pytest.raises(InterruptedError):
         github_status.check()
@@ -126,7 +134,7 @@ def test_github_status_check_outage(_mock_thread, mock_sleep, mock_log):
     session.get.assert_called_once_with('https://www.githubstatus.com/api/v2/components.json',
                                         timeout=EXPECTED_TIMEOUT)
     mocked_response.raise_for_status.assert_called_once_with()
-    mock_sleep.assert_called_once_with(sleep_time)
+    mock_sleep.assert_called_once_with(EXPECTED_SLEEP_TIME)
 
 
 @pytest.mark.parametrize('error',
@@ -143,8 +151,9 @@ def test_github_status_check_fail(_mock_thread, mock_sleep, mock_log, error):
     session = mock.create_autospec(requests.Session)
     session.get.return_value = mocked_response
     mocked_response.raise_for_status.side_effect = error
-    sleep_time = 1
-    github_status = _GithubStatus(sleep_time=sleep_time, session=session)
+    github_status = _GithubStatus(sleep_time=EXPECTED_SLEEP_TIME,
+                                  timeout=EXPECTED_TIMEOUT,
+                                  session=session)
 
     with pytest.raises(InterruptedError):
         github_status.check()
@@ -154,4 +163,4 @@ def test_github_status_check_fail(_mock_thread, mock_sleep, mock_log, error):
     session.get.assert_called_once_with('https://www.githubstatus.com/api/v2/components.json',
                                         timeout=EXPECTED_TIMEOUT)
     mocked_response.raise_for_status.assert_called_once_with()
-    mock_sleep.assert_called_once_with(sleep_time)
+    mock_sleep.assert_called_once_with(EXPECTED_SLEEP_TIME)

--- a/tests/unit/test_github_status.py
+++ b/tests/unit/test_github_status.py
@@ -5,6 +5,7 @@ import requests
 
 from ghmirror.data_structures.monostate import GithubStatus, _GithubStatus
 
+EXPECTED_TIMEOUT = 10
 
 @mock.patch('ghmirror.data_structures.monostate.threading.Thread')
 def test_create_github_status_singleton(_mock_thread):
@@ -100,7 +101,8 @@ def test_github_status_check_success(_mock_thread, mock_sleep, status):
         github_status.check()
 
     assert github_status.online is True
-    session.get.assert_called_once_with('https://www.githubstatus.com/api/v2/components.json', timeout=2)
+    session.get.assert_called_once_with('https://www.githubstatus.com/api/v2/components.json',
+                                        timeout=EXPECTED_TIMEOUT)
     mocked_response.raise_for_status.assert_called_once_with()
     mock_sleep.assert_called_once_with(sleep_time)
 
@@ -121,7 +123,8 @@ def test_github_status_check_outage(_mock_thread, mock_sleep, mock_log):
 
     assert github_status.online is False
     mock_log.warning.assert_called_once_with('Github API is offline, response: %s', mocked_response.text)
-    session.get.assert_called_once_with('https://www.githubstatus.com/api/v2/components.json', timeout=2)
+    session.get.assert_called_once_with('https://www.githubstatus.com/api/v2/components.json',
+                                        timeout=EXPECTED_TIMEOUT)
     mocked_response.raise_for_status.assert_called_once_with()
     mock_sleep.assert_called_once_with(sleep_time)
 
@@ -148,6 +151,7 @@ def test_github_status_check_fail(_mock_thread, mock_sleep, mock_log, error):
 
     assert github_status.online is False
     mock_log.warning.assert_called_once_with('Github API is offline, reason: %s', error)
-    session.get.assert_called_once_with('https://www.githubstatus.com/api/v2/components.json', timeout=2)
+    session.get.assert_called_once_with('https://www.githubstatus.com/api/v2/components.json',
+                                        timeout=EXPECTED_TIMEOUT)
     mocked_response.raise_for_status.assert_called_once_with()
     mock_sleep.assert_called_once_with(sleep_time)


### PR DESCRIPTION
`2s` is too small, lead to error

```
Github API is offline, reason: HTTPSConnectionPool(host='www.githubstatus.com', port=443): Read timed out. (read timeout=2)
```

Update it to be the same timeout (10s) as request timeout.