### PR TITLE
Revert "Revert "Unset CPU limits""

### DIFF
--- a/openshift/github-mirror-acceptance.yaml
+++ b/openshift/github-mirror-acceptance.yaml
@@ -13,6 +13,8 @@ objects:
 - apiVersion: batch/v1
   kind: Job
   metadata:
+    annotations:
+      ignore-check.kube-linter.io/unset-cpu-requirements: "no cpu limits"
     name: github-mirror-acceptance-${IMAGE_TAG}
   spec:
     backoffLimit: 5
@@ -42,7 +44,6 @@ objects:
                 cpu: ${CPU_REQUESTS}
               limits:
                 memory: ${MEMORY_LIMIT}
-                cpu: ${CPU_LIMIT}
 parameters:
 - name: IMAGE
   value: quay.io/app-sre/github-mirror
@@ -64,6 +65,4 @@ parameters:
 - name: MEMORY_LIMIT
   value: 128Mi
 - name: CPU_REQUESTS
-  value: 300m
-- name: CPU_LIMIT
-  value: 300m
+  value: 100m

--- a/openshift/github-mirror.yaml
+++ b/openshift/github-mirror.yaml
@@ -22,6 +22,8 @@ objects:
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
+    annotations:
+      ignore-check.kube-linter.io/unset-cpu-requirements: "no cpu limits"
     labels:
       app: github-mirror
     name: github-mirror
@@ -119,7 +121,6 @@ objects:
               cpu: ${CPU_REQUESTS}
             limits:
               memory: ${MEMORY_LIMIT}
-              cpu: ${CPU_LIMIT}
 - apiVersion: v1
   kind: Service
   metadata:
@@ -153,9 +154,7 @@ parameters:
 # we need more, we should probably increase the number
 # of replicas instead of touching it here.
 - name: CPU_REQUESTS
-  value: 500m
-- name: CPU_LIMIT
-  value: 1000m
+  value: 200m
 # These values are meant to be overridden by the
 # saas-herder parametrization
 - name: GITHUB_USERS


### PR DESCRIPTION
Reverts app-sre/github-mirror#99

Reapply unset cpu limits, as status check is switched to new endpoint, shouldn't be rated limited anymore.