### PR TITLE
Add retry to github status check

### DIFF
--- a/ghmirror/core/constants.py
+++ b/ghmirror/core/constants.py
@@ -19,6 +19,7 @@ System constants.
 GH_API = 'https://api.github.com'
 GH_STATUS_API = 'https://www.githubstatus.com/api/v2/components.json'
 REQUESTS_TIMEOUT = 10
+STATUS_MAX_RETRIES = 3
 STATUS_SLEEP_TIME = 1
 STATUS_TIMEOUT = 10
 PER_PAGE_ELEMENTS = 30

--- a/ghmirror/data_structures/monostate.py
+++ b/ghmirror/data_structures/monostate.py
@@ -25,6 +25,7 @@ import sys
 import hashlib
 
 import requests
+from requests.adapters import HTTPAdapter
 
 from prometheus_client import CollectorRegistry
 from prometheus_client import Counter
@@ -34,6 +35,7 @@ from prometheus_client import ProcessCollector
 
 from ghmirror.core.constants import (
     GH_STATUS_API,
+    STATUS_MAX_RETRIES,
     STATUS_SLEEP_TIME,
     STATUS_TIMEOUT,
 )
@@ -88,9 +90,11 @@ class _GithubStatus:
                                         STATUS_SLEEP_TIME))
         timeout = int(os.environ.get("GITHUB_STATUS_TIMEOUT",
                                      STATUS_TIMEOUT))
+        session = requests.Session()
+        session.mount('https://', HTTPAdapter(max_retries=STATUS_MAX_RETRIES))
         return cls(sleep_time=sleep_time,
                    timeout=timeout,
-                   session=requests.Session())
+                   session=session)
 
     def check(self):
         """

--- a/tests/unit/test_github_status.py
+++ b/tests/unit/test_github_status.py
@@ -24,10 +24,12 @@ def test_create_github_status_singleton(_mock_thread):
                              ({'GITHUB_STATUS_SLEEP_TIME': '3'}, 3, 10),
                              ({'GITHUB_STATUS_TIMEOUT': '2'}, 1, 2),
                          ])
+@mock.patch('ghmirror.data_structures.monostate.HTTPAdapter')
 @mock.patch('ghmirror.data_structures.monostate.requests.Session')
 @mock.patch('ghmirror.data_structures.monostate.threading.Thread')
 def test_create_github_status_with_sleep_time(mock_thread,
                                               mock_session,
+                                              mock_http_adapter,
                                               env,
                                               expected_sleep_time,
                                               expected_timeout):
@@ -42,6 +44,9 @@ def test_create_github_status_with_sleep_time(mock_thread,
     mock_thread.assert_called_once_with(target=github_status.check, daemon=True)
     mock_thread.return_value.start.assert_called_once_with()
     mock_session.assert_called_once_with()
+    mock_http_adapter.assert_called_once_with(max_retries=3)
+    mock_session.return_value.mount.assert_called_once_with('https://',
+                                                            mock_http_adapter.return_value)
 
 
 def build_github_status_response_builder(status):


### PR DESCRIPTION
There can be transient network issues for status check requests, add retry to it so it won't falsy go to offline.