### PR TITLE
Redistribute latency buckets

### DIFF
--- a/ghmirror/data_structures/monostate.py
+++ b/ghmirror/data_structures/monostate.py
@@ -32,6 +32,7 @@ from prometheus_client import (
     Histogram,
     ProcessCollector,
 )
+from prometheus_client.utils import INF
 from requests.adapters import HTTPAdapter
 
 from ghmirror.core.constants import (
@@ -269,6 +270,21 @@ class StatsCache(StatsCacheBorg):
                     labelnames=("cache", "status", "method", "user"),
                     documentation="request latency histogram",
                     registry=self.registry,
+                    buckets=(
+                        0.05,
+                        0.075,
+                        0.1,
+                        0.2,
+                        0.3,
+                        0.4,
+                        0.5,
+                        0.75,
+                        1.0,
+                        2.5,
+                        5.0,
+                        10.0,
+                        INF,
+                    ),
                 ),
             )
         elif item == "counter":


### PR DESCRIPTION
There are very little requests under 0.05s (0.02% in the last 28 days), so it doesn't make sense to keep all the granularity there. It is equally non important to keep the granularity over 5s, since there are almost no differences between the number of requests under 7.5s and 10s. We have added granularity in the area where we have the most of our requests (0.25s) as that can help us to define more precisely our SLOs.

APPSRE-9880