### PR TITLE
Use sessions for github requests

### DIFF
--- a/ghmirror/app/__init__.py
+++ b/ghmirror/app/__init__.py
@@ -23,6 +23,7 @@ import sys
 import flask
 from prometheus_client import generate_latest
 
+from ghmirror.app.extensions import session
 from ghmirror.core.constants import GH_API
 from ghmirror.core.mirror_requests import conditional_request
 from ghmirror.core.mirror_response import MirrorResponse
@@ -91,6 +92,7 @@ def ghmirror(path):
         url = url.rstrip("&")
 
     resp = conditional_request(
+        session=session,
         method=flask.request.method,
         url=url,
         auth=flask.request.headers.get("Authorization"),

--- a/ghmirror/app/extensions.py
+++ b/ghmirror/app/extensions.py
@@ -1,0 +1,3 @@
+import requests
+
+session = requests.Session()

--- a/ghmirror/app/extensions.py
+++ b/ghmirror/app/extensions.py
@@ -1,3 +1,7 @@
+"""
+Module to create a requests session that will be used to make all the requests to the GitHub API.
+"""
+
 import requests
 
 session = requests.Session()

--- a/ghmirror/core/mirror_requests.py
+++ b/ghmirror/core/mirror_requests.py
@@ -154,6 +154,7 @@ def conditional_request(session, method, url, auth, data=None, url_params=None):
     return offline_request(method, url, auth)
 
 
+# pylint: disable-msg=too-many-locals
 def online_request(session, method, url, auth, data=None, url_params=None):
     """
     Implements conditional requests.

--- a/ghmirror/decorators/checks.py
+++ b/ghmirror/decorators/checks.py
@@ -20,6 +20,7 @@ import os
 from functools import wraps
 
 import flask
+import requests
 
 from ghmirror.core.constants import GH_API
 from ghmirror.core.mirror_requests import conditional_request
@@ -62,7 +63,10 @@ def check_user(function):
 
         # Using the Authorization header to get the user information
         user_url = f"{GH_API}/user"
-        resp = conditional_request(method="GET", url=user_url, auth=authorization)
+        # Create a new session is fine here, cause it's not called often
+        resp = conditional_request(
+            session=requests.Session(), method="GET", url=user_url, auth=authorization
+        )
 
         # Fail early when Github API tells something is wrong
         if resp.status_code != 200:

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -114,7 +114,7 @@ def test_healthz(client):
 
 
 @mock.patch(
-    "ghmirror.core.mirror_requests.requests.request",
+    "ghmirror.app.extensions.session.request",
     side_effect=mocked_requests_get_etag,
 )
 @mock.patch("ghmirror.data_structures.monostate.requests.Session")
@@ -168,7 +168,7 @@ def test_mirror_etag(mock_monitor_session, _mock_get, client):
 
 
 @mock.patch(
-    "ghmirror.core.mirror_requests.requests.request",
+    "ghmirror.app.extensions.session.request",
     side_effect=mocked_requests_get_last_modified,
 )
 @mock.patch("ghmirror.data_structures.monostate.requests.Session")
@@ -221,7 +221,7 @@ def test_mirror_last_modified(mock_monitor_session, _mock_get, client):
 
 
 @mock.patch(
-    "ghmirror.core.mirror_requests.requests.request",
+    "ghmirror.app.extensions.session.request",
     side_effect=mocked_requests_get_last_modified,
 )
 @mock.patch("ghmirror.data_structures.monostate.requests.Session")
@@ -241,7 +241,7 @@ def test_mirror_upstream_call(mock_monitor_session, mocked_request, client):
 
 
 @mock.patch(
-    "ghmirror.core.mirror_requests.requests.request",
+    "ghmirror.app.extensions.session.request",
     side_effect=mocked_requests_get_last_modified,
 )
 @mock.patch("ghmirror.data_structures.monostate.requests.Session")
@@ -266,7 +266,7 @@ def test_mirror_non_get(mock_monitor_session, mocked_request, client):
     "ghmirror.decorators.checks.conditional_request",
     side_effect=mocked_requests_get_user_orgs_auth,
 )
-@mock.patch("ghmirror.core.mirror_requests.requests.request")
+@mock.patch("ghmirror.app.extensions.session.request")
 @mock.patch("ghmirror.data_structures.monostate.requests.Session")
 def test_mirror_authorized_user(
     mock_monitor_session, mocked_request, mocked_cond_request, client
@@ -292,7 +292,7 @@ def test_mirror_authorized_user(
     "ghmirror.decorators.checks.conditional_request",
     side_effect=mocked_requests_get_user_orgs_auth,
 )
-@mock.patch("ghmirror.core.mirror_requests.requests.request")
+@mock.patch("ghmirror.app.extensions.session.request")
 @mock.patch("ghmirror.data_structures.monostate.requests.Session")
 def test_mirror_authorized_user_cached(
     mock_monitor_session, mocked_request, mocked_cond_request, client
@@ -358,7 +358,7 @@ def test_mirror_auth_error(mock_monitor_session, _mocked_cond_request, client):
 
 
 @mock.patch(
-    "ghmirror.core.mirror_requests.requests.request",
+    "ghmirror.app.extensions.session.request",
     side_effect=mocked_requests_get_etag,
 )
 @mock.patch("ghmirror.data_structures.monostate.requests.Session")
@@ -422,7 +422,7 @@ def test_offline_mode(mock_monitor_session, _mock_request, client):
 
 
 @mock.patch(
-    "ghmirror.core.mirror_requests.requests.request",
+    "ghmirror.app.extensions.session.request",
     side_effect=mocked_requests_get_etag,
 )
 @mock.patch("ghmirror.data_structures.monostate.requests.Session")
@@ -465,7 +465,7 @@ def test_offline_mode_upstream_error(mock_monitor_session, _mock_request, client
 
 
 @mock.patch(
-    "ghmirror.core.mirror_requests.requests.request",
+    "ghmirror.app.extensions.session.request",
     side_effect=mocked_requests_rate_limited,
 )
 @mock.patch("ghmirror.data_structures.monostate.requests.Session")
@@ -512,7 +512,7 @@ def test_rate_limited(_mock_monitor_session, mock_request, client):
 
 
 @mock.patch(
-    "ghmirror.core.mirror_requests.requests.request",
+    "ghmirror.app.extensions.session.request",
     side_effect=mocked_requests_api_corner_case,
 )
 @mock.patch("ghmirror.data_structures.monostate.requests.Session")
@@ -575,7 +575,7 @@ def test_pagination_corner_case_custom_page_elements(
 
 @mock.patch("ghmirror.core.mirror_requests.PER_PAGE_ELEMENTS", 2)
 @mock.patch(
-    "ghmirror.core.mirror_requests.requests.request",
+    "ghmirror.app.extensions.session.request",
     side_effect=mocked_requests_api_corner_case,
 )
 @mock.patch("ghmirror.data_structures.monostate.requests.Session")
@@ -631,7 +631,7 @@ def test_pagination_corner_case(mock_monitor_session, _mock_get, client):
 
 
 @mock.patch(
-    "ghmirror.core.mirror_requests.requests.request",
+    "ghmirror.app.extensions.session.request",
     side_effect=requests.exceptions.Timeout,
 )
 @mock.patch("ghmirror.data_structures.monostate.requests.Session")
@@ -656,7 +656,7 @@ def test_mirror_request_timeout(mock_monitor_session, _mock_get, client):
 
 
 @mock.patch(
-    "ghmirror.core.mirror_requests.requests.request",
+    "ghmirror.app.extensions.session.request",
     side_effect=mocked_requests_get_etag,
 )
 @mock.patch("ghmirror.data_structures.monostate.requests.Session")
@@ -711,7 +711,7 @@ def test_mirror_request_timeout_hit(mock_monitor_session, mock_get, client):
 
 
 @mock.patch(
-    "ghmirror.core.mirror_requests.requests.request",
+    "ghmirror.app.extensions.session.request",
     side_effect=mocked_requests_get_etag,
 )
 @mock.patch("ghmirror.data_structures.monostate.requests.Session")
@@ -766,7 +766,7 @@ def test_mirror_request_5xx(mock_monitor_session, mock_get, client):
 
 
 @mock.patch(
-    "ghmirror.core.mirror_requests.requests.request",
+    "ghmirror.app.extensions.session.request",
     side_effect=mocked_requests_get_etag,
 )
 @mock.patch("ghmirror.data_structures.monostate.requests.Session")
@@ -821,7 +821,7 @@ def test_mirror_request_5xx_miss(mock_monitor_session, mock_get, client):
 
 
 @mock.patch(
-    "ghmirror.core.mirror_requests.requests.request",
+    "ghmirror.app.extensions.session.request",
     side_effect=mocked_requests_get_etag,
 )
 @mock.patch("ghmirror.data_structures.monostate.requests.Session")
@@ -876,7 +876,7 @@ def test_mirror_request_connection_error_hit(mock_monitor_session, mock_get, cli
 
 
 @mock.patch(
-    "ghmirror.core.mirror_requests.requests.request",
+    "ghmirror.app.extensions.session.request",
     side_effect=mocked_requests_get_etag,
 )
 @mock.patch("ghmirror.data_structures.monostate.requests.Session")

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from unittest.mock import ANY
 
 import pytest
 import requests
@@ -276,7 +277,7 @@ def test_mirror_authorized_user(
     )
     client.get("/repos/app-sre/github-mirror", headers={"Authorization": "foo"})
     mocked_cond_request.assert_called_with(
-        auth="foo", method="GET", url="https://api.github.com/user"
+        session=ANY, auth="foo", method="GET", url="https://api.github.com/user"
     )
     mocked_request.assert_called_with(
         method="GET",


### PR DESCRIPTION
Create a requtes.Session at the top level of the flask service and pass it in to the core methods. By this the number of TCP roundtrips is drastically reduced. In local testing improvement was around 20%.