### PR TITLE
Update IMAGE_PULL_SECRETS parameter to be the whole list

### DIFF
--- a/openshift/github-mirror-acceptance.yaml
+++ b/openshift/github-mirror-acceptance.yaml
@@ -8,8 +8,7 @@ objects:
   kind: ServiceAccount
   metadata:
     name: ${SERVICE_ACCOUNT}
-  imagePullSecrets:
-  - name: ${IMAGE_PULL_SECRET}
+  imagePullSecrets: "${{IMAGE_PULL_SECRETS}}"
 - apiVersion: batch/v1
   kind: Job
   metadata:
@@ -66,3 +65,5 @@ parameters:
   value: 128Mi
 - name: CPU_REQUESTS
   value: 100m
+- name: IMAGE_PULL_SECRETS
+  value: '[]'

--- a/openshift/github-mirror.yaml
+++ b/openshift/github-mirror.yaml
@@ -17,8 +17,7 @@ objects:
   kind: ServiceAccount
   metadata:
     name: ${SERVICE_ACCOUNT}
-  imagePullSecrets:
-  - name: ${IMAGE_PULL_SECRET}
+  imagePullSecrets: "${{IMAGE_PULL_SECRETS}}"
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -180,3 +179,5 @@ parameters:
   value: '1'
 - name: GITHUB_STATUS_TIMEOUT
   value: '10'
+- name: IMAGE_PULL_SECRETS
+  value: '[]'


### PR DESCRIPTION
Fix error event `Unable to retrieve some image pull secrets (${IMAGE_PULL_SECRET}); attempting to pull the image may not succeed.` when no secrets specified in openshift template.