### PR TITLE
abort requests for [bot]

### DIFF
--- a/ghmirror/core/mirror_requests.py
+++ b/ghmirror/core/mirror_requests.py
@@ -20,6 +20,7 @@ Implements conditional requests
 import hashlib
 import logging
 
+import flask
 import requests
 
 from ghmirror.core.constants import (
@@ -151,6 +152,12 @@ def conditional_request(session, method, url, auth, data=None, url_params=None):
     the upstream API is online of offline to decide which
     request routine to call.
     """
+    # abort calls for members/*[bot] as a workaround
+    # since this endpoint always returns a 404
+    # while usage of GHPRB in jenkins exists
+    if "/members/" in url and url.endswith("[bot]"):
+        flask.abort(404)
+
     if GithubStatus().online:
         return online_request(session, method, url, auth, data, url_params)
     return offline_request(method, url, auth)


### PR DESCRIPTION
github-mirror is not caching 404 that has always returned a 404.
in other words, we lose all our rate quota for calls that will always return a 404.

let's just return a 404.