### PR TITLE
fix commit regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ processes. Every time the server is started, the cache is initialized empty.
 Using Redis prevents the cache from being lost when the github mirror server
 is restarted.
 
-
 ## Quick Start
 
 Run the Docker container:

--- a/ghmirror/core/mirror_requests.py
+++ b/ghmirror/core/mirror_requests.py
@@ -226,7 +226,7 @@ def online_request(session, method, url, auth, data=None, url_params=None):
     # It should be considered a temporary workaround until github fixes
     # on their side
     if cached_response and re.match(
-        r"^https://api.github.com/repos/[^/]+/[^/]+/commits/[^/]+$", url
+        r"^https://api.github.com/repos/[^/]+/[^/]+/commits/[0-9a-f]{40}$", url
     ):
         return _handle_not_changed(
             session,


### PR DESCRIPTION
When getting commit sha with branch name(e.g main/master), we should not use the cached_response.