### PR TITLE
Fix authorized user validation bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,3 @@ omit = ["*/tests/*"]
 
 [tool.coverage.report]
 fail_under = 98
-
-[tool.ruff.lint.pylint]
-max-returns = 6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,6 @@ omit = ["*/tests/*"]
 
 [tool.coverage.report]
 fail_under = 97
+
+[tool.ruff.lint.pylint]
+max-returns = 7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,4 +44,4 @@ omit = ["*/tests/*"]
 fail_under = 98
 
 [tool.ruff.lint.pylint]
-max-returns = 7
+max-returns = 6

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -282,7 +282,7 @@ def test_mirror_no_authorized_user(
     mocked_request.assert_called_with(
         method="GET",
         headers={"Authorization": "foo"},
-        url="https://api.github.com/repos/" "app-sre/github-mirror",
+        url="https://api.github.com/repos/app-sre/github-mirror",
         timeout=REQUESTS_TIMEOUT,
         params={"per_page": PER_PAGE_ELEMENTS},
     )
@@ -309,7 +309,7 @@ def test_mirror_no_authorized_user_cached(
     mocked_request.assert_called_with(
         method="GET",
         headers={"Authorization": auth},
-        url="https://api.github.com/repos/" "app-sre/github-mirror",
+        url="https://api.github.com/repos/app-sre/github-mirror",
         timeout=REQUESTS_TIMEOUT,
         params={"per_page": PER_PAGE_ELEMENTS},
     )

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -263,6 +263,58 @@ def test_mirror_non_get(mock_monitor_session, mocked_request, client):
     )
 
 
+@mock.patch(
+    "ghmirror.decorators.checks.conditional_request",
+    side_effect=mocked_requests_get_user_orgs_auth,
+)
+@mock.patch("ghmirror.utils.extensions.session.request")
+@mock.patch("ghmirror.data_structures.monostate.requests.Session")
+def test_mirror_no_authorized_user(
+    mock_monitor_session, mocked_request, mocked_cond_request, client
+):
+    setup_mocked_requests_session_get(
+        mock_monitor_session, mocked_requests_monitor_good
+    )
+    client.get("/repos/app-sre/github-mirror", headers={"Authorization": "foo"})
+    mocked_cond_request.assert_called_with(
+        session=ANY, auth="foo", method="GET", url="https://api.github.com/user"
+    )
+    mocked_request.assert_called_with(
+        method="GET",
+        headers={"Authorization": "foo"},
+        url="https://api.github.com/repos/" "app-sre/github-mirror",
+        timeout=REQUESTS_TIMEOUT,
+        params={"per_page": PER_PAGE_ELEMENTS},
+    )
+
+
+@mock.patch(
+    "ghmirror.decorators.checks.conditional_request",
+    side_effect=mocked_requests_get_user_orgs_auth,
+)
+@mock.patch("ghmirror.utils.extensions.session.request")
+@mock.patch("ghmirror.data_structures.monostate.requests.Session")
+def test_mirror_no_authorized_user_cached(
+    mock_monitor_session, mocked_request, mocked_cond_request, client
+):
+    setup_mocked_requests_session_get(
+        mock_monitor_session, mocked_requests_monitor_good
+    )
+    users_cache = UsersCache()
+    auth = "foo"
+    users_cache.add(auth)
+
+    client.get("/repos/app-sre/github-mirror", headers={"Authorization": auth})
+    assert not mocked_cond_request.called
+    mocked_request.assert_called_with(
+        method="GET",
+        headers={"Authorization": auth},
+        url="https://api.github.com/repos/" "app-sre/github-mirror",
+        timeout=REQUESTS_TIMEOUT,
+        params={"per_page": PER_PAGE_ELEMENTS},
+    )
+
+
 @mock.patch("ghmirror.decorators.checks.AUTHORIZED_USERS", "app-sre-bot")
 @mock.patch(
     "ghmirror.decorators.checks.conditional_request",


### PR DESCRIPTION
This change fixes a bug in the `check_user` decorator, which causes an exception when the `GITHUB_USERS` variable is not present but an authorization header is specified in the request (e.g., when accessing a private organization).

The use case is when multiple users consume the service accessing private EMU organizations. I.e. they must provide authorization header, but we don't know all possible users upfront whitelist the logins.

- Updated `ghmirror/decorators/checks.py` with a fix.
- Added two more `tests/functional/test_api.py` tests.
- Updated `pyproject.toml` rule to allow 7 max-returns (please suggest better conditional logic in `check_user` if not happy).

**Current behaviour:**

```bash
export GITHUB_USERS=""

curl -L \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer mytoken" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  http://localhost:8080/orgs/myorg/repos
```

```json
{
  "message": "Error reaching https://api.github.com: AttributeError"
}
```

**Expected behaviour:**

API response is returned.