### PR TITLE
:page_facing_up: add missing license file to final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ FROM        registry.access.redhat.com/ubi9/ubi-minimal:9.4-1227@sha256:f182b500
 RUN         microdnf upgrade -y && \
             microdnf install -y python3.11 && \
             microdnf clean all
+COPY        LICENSE /licenses/LICENSE
 USER        1001
 WORKDIR     /ghmirror
 ENV         VIRTUAL_ENV=/ghmirror/venv


### PR DESCRIPTION
The `enterprise-contract` enforces this file in our image.