### PR TITLE
Revert workaround added for github rate limit

### DIFF
--- a/ghmirror/core/mirror_requests.py
+++ b/ghmirror/core/mirror_requests.py
@@ -21,7 +21,6 @@ import hashlib
 import logging
 import re
 
-import flask
 import requests
 
 from ghmirror.core.constants import (
@@ -153,12 +152,6 @@ def conditional_request(session, method, url, auth, data=None, url_params=None):
     the upstream API is online of offline to decide which
     request routine to call.
     """
-    # abort calls for members/*[bot] as a workaround
-    # since this endpoint always returns a 404
-    # while usage of GHPRB in jenkins exists
-    if "/members/" in url and url.endswith("[bot]"):
-        flask.abort(404)
-
     if GithubStatus().online:
         return online_request(session, method, url, auth, data, url_params)
     return offline_request(method, url, auth)

--- a/ghmirror/core/mirror_requests.py
+++ b/ghmirror/core/mirror_requests.py
@@ -19,7 +19,6 @@ Implements conditional requests
 # ruff: noqa: PLR2004
 import hashlib
 import logging
-import re
 
 import requests
 
@@ -207,31 +206,6 @@ def online_request(session, method, url, auth, data=None, url_params=None):
         last_mod = cached_response.headers.get("Last-Modified")
         if last_mod is not None:
             headers["If-Modified-Since"] = last_mod
-
-    # https://issues.redhat.com/browse/APPSRE-11127
-    # as per https://github.com/orgs/community/discussions/143752
-    # github is now updating the commit API return payload with a
-    # `verified_at` timestamp, which updates the etag continuously.
-    # So commits get CACHE_MISS very frequently for individual commits,
-    # branch commits and pull-request commits.
-    # This lowers the API calls on individual commits, considering
-    # the commit shas are immutable
-    # It should be considered a temporary workaround until github fixes
-    # on their side
-    if cached_response and re.match(
-        r"^https://api.github.com/repos/[^/]+/[^/]+/commits/[0-9a-f]{40}$", url
-    ):
-        return _handle_not_changed(
-            session,
-            cached_response,
-            per_page_elements,
-            headers,
-            method,
-            url,
-            parameters,
-            cache,
-            cache_key,
-        )
 
     resp = _online_request(
         session=session,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,4 +41,4 @@ branch = true
 omit = ["*/tests/*"]
 
 [tool.coverage.report]
-fail_under = 97
+fail_under = 98


### PR DESCRIPTION
now that https://github.com/orgs/community/discussions/143752 is fixed, revert changes:

* https://github.com/app-sre/github-mirror/pull/173
* https://github.com/app-sre/github-mirror/pull/175
* https://github.com/app-sre/github-mirror/pull/177


https://issues.redhat.com/browse/APPSRE-11127