### PR TITLE
fix: ensure no conditional requests for pagination edge case

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GitHub Mirror
 
 GitHub API mirror that caches the responses and implements
-[conditional requests](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#conditional-requests).
+[conditional requests](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#use-conditional-requests-if-appropriate).
 
 With conditional requests, all the calls are forwarded to the Github API, but
 when the GitHub API replies with a 304 HTTP code, meaning that the resource

--- a/ghmirror/core/mirror_requests.py
+++ b/ghmirror/core/mirror_requests.py
@@ -117,7 +117,8 @@ def _handle_not_changed(
     cache_key,
 ):
     if len(cached_response.json()) == per_page_elements and not cached_response.links:
-        headers.pop("If-None-Match")
+        headers.pop("If-None-Match", None)
+        headers.pop("If-Modified-Since", None)
         resp = session.request(
             method=method,
             url=url,

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -40,20 +40,14 @@ class MockResponse:
 
 
 def mocked_requests_get_etag(*_args, **kwargs):
-    if "If-Modified-Since" in kwargs["headers"]:
-        return MockResponse("", {}, 304)
-
-    if "If-None-Match" in kwargs["headers"]:
+    if "If-Modified-Since" in kwargs["headers"] or "If-None-Match" in kwargs["headers"]:
         return MockResponse("", {}, 304)
 
     return MockResponse("", {"ETag": "foo"}, 200)
 
 
 def mocked_requests_get_last_modified(*_args, **kwargs):
-    if "If-Modified-Since" in kwargs["headers"]:
-        return MockResponse("", {}, 304)
-
-    if "If-None-Match" in kwargs["headers"]:
+    if "If-Modified-Since" in kwargs["headers"] or "If-None-Match" in kwargs["headers"]:
         return MockResponse("", {}, 304)
 
     return MockResponse("", {"Last-Modified": "bar"}, 200)
@@ -95,10 +89,15 @@ def mocked_requests_rate_limited(*_args, **_kwargs):
 
 
 def mocked_requests_api_corner_case(*_args, **kwargs):
-    if "If-None-Match" in kwargs["headers"]:
+    if "If-None-Match" in kwargs["headers"] or "If-Modified-Since" in kwargs["headers"]:
         return MockResponse("", {}, 304, json_content=[{"a": "b"}, {"c", "d"}])
 
-    return MockResponse("", {"ETag": "foo"}, 200, json_content=[{"a": "b"}, {"c", "d"}])
+    return MockResponse(
+        "",
+        {"ETag": "foo", "Last-Modified": "bar"},
+        200,
+        json_content=[{"a": "b"}, {"c", "d"}],
+    )
 
 
 @pytest.fixture(name="client")


### PR DESCRIPTION
Ensure no conditional request send for pagination edge case (response count is a full page).         `If-None-Match` or `If-Modified-Since` will lead to conditional request, unset both to fetch a fresh response from upstream.

[APPSRE-12325](https://issues.redhat.com/browse/APPSRE-12325)

### Enhancements to conditional request handling:

* [`ghmirror/core/mirror_requests.py`](diffhunk://#diff-b65064d2dfc0b574509b9afa3a22ef4675bdbe4f2ff285de9b5ce1288c7faaecL120-R121): Updated the `_handle_not_changed` function to remove both `If-None-Match` and `If-Modified-Since` headers when handling cached responses. This ensures proper fallback behavior when conditional requests are used.

### Updates to tests:

* [`tests/functional/test_api.py`](diffhunk://#diff-c9a73edcb83636788afae9cca59e049c6ab9b641992a419b6df0c1c197e36be0L43-R50): Modified mocked request functions (`mocked_requests_get_etag`, `mocked_requests_get_last_modified`, and `mocked_requests_api_corner_case`) to handle both `If-None-Match` and `If-Modified-Since` headers in conditional request scenarios. Additionally, updated mock responses to include both `ETag` and `Last-Modified` headers where applicable. [[1]](diffhunk://#diff-c9a73edcb83636788afae9cca59e049c6ab9b641992a419b6df0c1c197e36be0L43-R50) [[2]](diffhunk://#diff-c9a73edcb83636788afae9cca59e049c6ab9b641992a419b6df0c1c197e36be0L98-R100)

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4): Updated the link to GitHub's documentation on conditional requests to point to the latest version and best practices for using the REST API.


Related to:
* https://github.com/app-sre/github-mirror/pull/117
* https://github.com/app-sre/github-mirror/pull/113
* https://github.com/app-sre/github-mirror/pull/57