### PR TITLE
fix(resource-template): amend typo in github-mirror param

### DIFF
--- a/openshift/github-mirror.yaml
+++ b/openshift/github-mirror.yaml
@@ -173,7 +173,7 @@ parameters:
   value: '3'
 - name: SERVICE_ACCOUNT
   value: "github-mirror"
-  deplayName: github-mirror service account
+  displayName: github-mirror service account
   description: name of the service account to use when deploying the pod
 - name: GITHUB_STATUS_SLEEP_TIME
   value: '1'


### PR DESCRIPTION
the `SERVICE_ACCOUNT` parameter of _openshift/github-mirror.yaml_ declared `deplayName`.  that's probably a typo; fix it by renaming to `displayName`.