### PR TITLE
Add Kustomize base structure for ArgoCD deployment

### DIFF
--- a/openshift/deploy/base/deployment.yaml
+++ b/openshift/deploy/base/deployment.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: github-mirror
+  annotations:
+    ignore-check.kube-linter.io/unset-cpu-requirements: "no cpu limits"
+  labels:
+    app: github-mirror
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app: github-mirror
+  template:
+    metadata:
+      labels:
+        app: github-mirror
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - github-mirror
+              topologyKey: kubernetes.io/hostname
+            weight: 90
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - github-mirror
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+      serviceAccountName: github-mirror
+      containers:
+      - name: github-mirror
+        image: quay.io/redhat-services-prod/app-sre-tenant/github-mirror-master/github-mirror-master:latest
+        imagePullPolicy: Always
+        env:
+        - name: GITHUB_USERS
+          value: app-sre-bot:cs-sre-bot
+        - name: GITHUB_MIRROR_URL
+          value: https://github-mirror.stage.devshift.net
+        - name: CACHE_TYPE
+          value: redis
+        - name: PRIMARY_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              name: ghmirror-elasticache
+              key: db.endpoint
+        - name: READER_ENDPOINT
+          value: ""
+        - name: REDIS_PORT
+          valueFrom:
+            secretKeyRef:
+              name: ghmirror-elasticache
+              key: db.port
+        - name: REDIS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: ghmirror-elasticache
+              key: db.auth_token
+        - name: REDIS_SSL
+          value: "True"
+        - name: GITHUB_STATUS_SLEEP_TIME
+          value: "1"
+        - name: GITHUB_STATUS_TIMEOUT
+          value: "10"
+        ports:
+        - name: http
+          containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 10
+          timeoutSeconds: 3
+        resources:
+          requests:
+            memory: 800Mi
+            cpu: 200m
+          limits:
+            memory: 1Gi

--- a/openshift/deploy/base/kustomization.yaml
+++ b/openshift/deploy/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- deployment.yaml
+- serviceaccount.yaml
+- service.yaml
+- poddisruptionbudget.yaml
+
+# Use labels instead of commonLabels - only adds to metadata, not selectors
+labels:
+- pairs:
+    app.kubernetes.io/name: github-mirror
+    app.kubernetes.io/part-of: app-sre

--- a/openshift/deploy/base/poddisruptionbudget.yaml
+++ b/openshift/deploy/base/poddisruptionbudget.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: github-mirror
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: github-mirror

--- a/openshift/deploy/base/service.yaml
+++ b/openshift/deploy/base/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: github-mirror
+  labels:
+    app: github-mirror
+spec:
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080
+    name: http
+  selector:
+    app: github-mirror

--- a/openshift/deploy/base/serviceaccount.yaml
+++ b/openshift/deploy/base/serviceaccount.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: github-mirror


### PR DESCRIPTION
Convert OpenShift Template to Kustomize base resources to support ArgoCD GitOps deployment pattern. This enables environment-specific overlays to be managed in the app-sre-cd GitOps repository.

Changes:
- Add openshift/deploy/base/ directory structure
- Extract Deployment, Service, ServiceAccount, and PodDisruptionBudget from template to individual resource files
- Add base kustomization.yaml with appropriate labels
- Maintain existing functionality with sensible defaults