### PR TITLE
fix: add error context to acceptance test assertions

### DIFF
--- a/acceptance/test_basic.py
+++ b/acceptance/test_basic.py
@@ -14,9 +14,14 @@ def test_get_repo(path, code, cache):
 
     response = requests.get(url, headers=headers, timeout=60)
 
-    assert response.status_code == code
+    assert response.status_code == code, (
+        f"Expected {code}, got {response.status_code}: {response.text[:200]}"
+    )
     if cache is not None:
-        assert response.headers["X-Cache"] == cache
+        actual_cache = response.headers.get("X-Cache")
+        assert actual_cache == cache, (
+            f"Expected X-Cache={cache}, got {actual_cache}"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add actual status code and response body to assertion messages in acceptance tests
- Add actual X-Cache header value to cache assertion messages

Bare `assert` statements only produce `AssertionError` with no detail, making it impossible to diagnose failures from job logs alone. With this change, a failure like a 401 from a bad token would show:

```
AssertionError: Expected 200, got 401: {"message": "Bad credentials"...}
```

instead of just:

```
AssertionError
```

No change to test behavior - same requests, same pass/fail criteria.

## Test plan

- [ ] Verify acceptance test still passes when service is healthy
- [ ] Verify failure output includes status code and response body