### PR TITLE
fix(security): replace pickle with JSON serialization in Redis cache

### DIFF
--- a/acceptance/test_basic.py
+++ b/acceptance/test_basic.py
@@ -19,9 +19,7 @@ def test_get_repo(path, code, cache):
     )
     if cache is not None:
         actual_cache = response.headers.get("X-Cache")
-        assert actual_cache == cache, (
-            f"Expected X-Cache={cache}, got {actual_cache}"
-        )
+        assert actual_cache == cache, f"Expected X-Cache={cache}, got {actual_cache}"
 
 
 if __name__ == "__main__":

--- a/ghmirror/data_structures/redis_data_structures.py
+++ b/ghmirror/data_structures/redis_data_structures.py
@@ -14,11 +14,15 @@
 
 """Caching data in Redis."""
 
+import base64
+import json
 import os
-import pickle
 from random import randint
 
 import redis
+from requests.models import Response
+from requests.structures import CaseInsensitiveDict
+from requests.utils import get_encoding_from_headers
 
 PRIMARY_ENDPOINT = os.environ.get("PRIMARY_ENDPOINT", "localhost")
 READER_ENDPOINT = os.environ.get("READER_ENDPOINT", PRIMARY_ENDPOINT)
@@ -35,19 +39,19 @@ class RedisCache:
         self.ro_cache = self._get_connection(READER_ENDPOINT)
 
     def __contains__(self, item):
-        sr_key = self._serialize(item)
+        sr_key = self._serialize_key(item)
         return self.ro_cache.exists(sr_key)
 
     def __getitem__(self, item):
-        sr_key = self._serialize(item)
+        sr_key = self._serialize_key(item)
         sr_value = self.ro_cache.get(sr_key)
         if sr_value is None:
             raise KeyError(item)
-        return self._deserialize(sr_value)
+        return self._deserialize_response(sr_value)
 
     def __setitem__(self, key, value):
-        sr_key = self._serialize(key)
-        sr_value = self._serialize(value)
+        sr_key = self._serialize_key(key)
+        sr_value = self._serialize_response(value)
         # randomize cache expiration time (1 hr increments) from 1 hr to 6 mon
         rand_val = randint(1, 4320)
         self.wr_cache.set(sr_key, sr_value, ex=3600 * rand_val)
@@ -67,7 +71,12 @@ class RedisCache:
         while cursor != 0:
             cursor, data = self.wr_cache.scan(cursor)
             for item in data:
-                yield self._deserialize(item)
+                try:
+                    yield self._deserialize_key(item)
+                except json.JSONDecodeError:
+                    # Entry written by a previous, pickle-based version of the
+                    # cache. It will expire on its own; skip it.
+                    continue
 
     @staticmethod
     def _get_connection(host):
@@ -79,11 +88,37 @@ class RedisCache:
         return redis.Redis(**parameters)
 
     @staticmethod
-    def _serialize(item):
-        """Serialize items for storage in Redis"""
-        return pickle.dumps(item)
+    def _serialize_key(key):
+        """Serialize a cache key for storage in Redis"""
+        return json.dumps(key).encode()
 
     @staticmethod
-    def _deserialize(item):
-        """Deserialize items stored in Redis"""
-        return pickle.loads(item)  # noqa: S301
+    def _deserialize_key(key):
+        """Deserialize a cache key stored in Redis"""
+        return json.loads(key)
+
+    @staticmethod
+    def _serialize_response(response):
+        """Serialize a requests.Response-like object for storage in Redis.
+
+        Only the fields needed to rebuild the response are stored (as JSON),
+        rather than pickling the object, so reading the cache can never
+        trigger arbitrary code execution.
+        """
+        payload = {
+            "status_code": response.status_code,
+            "headers": dict(response.headers),
+            "content": base64.b64encode(response.content or b"").decode("ascii"),
+        }
+        return json.dumps(payload).encode()
+
+    @staticmethod
+    def _deserialize_response(item):
+        """Rebuild a requests.Response from its JSON representation"""
+        payload = json.loads(item)
+        response = Response()
+        response.status_code = payload["status_code"]
+        response.headers = CaseInsensitiveDict(payload["headers"])
+        response.encoding = get_encoding_from_headers(response.headers)
+        response._content = base64.b64decode(payload["content"])  # noqa: SLF001
+        return response

--- a/tests/unit/test_requests.py
+++ b/tests/unit/test_requests.py
@@ -1,4 +1,5 @@
 # ruff: noqa: SLF001
+import pickle
 from random import randint
 from unittest import (
     TestCase,
@@ -107,6 +108,27 @@ class TestRequestsCache(TestCase):
         self.assertEqual(requests_cache_01.__sizeof__(), RAND_CACHE_SIZE)
 
         self.assertRaises(KeyError, lambda: requests_cache_01["bar"])
+
+    @mock.patch("ghmirror.data_structures.requests_cache.CACHE_TYPE", "redis")
+    @mock.patch(
+        "ghmirror.data_structures.redis_data_structures.REDIS_TOKEN", "mysecret"
+    )
+    @mock.patch("ghmirror.data_structures.redis_data_structures.REDIS_SSL", "True")
+    @mock.patch(
+        "ghmirror.data_structures.redis_data_structures.redis.Redis",
+        side_effect=mocked_redis_cache,
+    )
+    def test_skips_legacy_pickle_entries_on_scan(self, _mock_cache):
+        """Entries written by the old pickle-based cache must not crash iteration."""
+        requests_cache_01 = RequestsCache()
+        requests_cache_01.wr_cache.cache["legacy"] = pickle.dumps("legacy-value")
+        requests_cache_01["foo"] = MockResponse(
+            content="bar", headers={}, status_code=200, text=""
+        )
+
+        keys = list(requests_cache_01)
+        self.assertIn("foo", keys)
+        self.assertNotIn("legacy-value", keys)
 
     @mock.patch("ghmirror.data_structures.requests_cache.CACHE_TYPE", "in-memory")
     def test_interface_in_memory(self):


### PR DESCRIPTION
Redis-stored cache entries were deserialized with pickle.loads(), so any actor with write access to the shared Redis instance could achieve remote code execution in every github-mirror replica. Cached responses are now stored as JSON (status_code, headers, base64 content) and rebuilt into a requests.Response, so reading a cache entry can no longer execute arbitrary code. Also reformats an unrelated line in acceptance/test_basic.py flagged by ruff format.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>