### PR TITLE
docs(security): add SECURITY.md disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+This repository is a Red Hat AppSRE service that mirrors and caches
+GitHub API responses, using conditional requests to reduce upstream
+API quota consumption.
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities through public GitHub
+issues or pull requests.
+
+To report a security issue in this repository, contact Red Hat
+Product Security:
+
+- Email: secalert@redhat.com
+- PGP key and additional details: https://access.redhat.com/security/team/contact
+
+Red Hat Product Security will acknowledge your report and coordinate
+remediation and disclosure.


### PR DESCRIPTION
Fixes FIND-009: the repository had no SECURITY.md or vulnerability disclosure policy, so external reporters had no documented channel for responsible disclosure and OpenSSF Scorecard's Security-Policy check would score 0/10.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>